### PR TITLE
Unbreak ci release

### DIFF
--- a/.changeset/new-rivers-shake.md
+++ b/.changeset/new-rivers-shake.md
@@ -1,0 +1,5 @@
+---
+"@effect-native/bun-test": patch
+---
+
+relax peer dependencies

--- a/packages-native/bun-test/package.json
+++ b/packages-native/bun-test/package.json
@@ -37,8 +37,7 @@
   },
   "peerDependencies": {
     "effect": ">=3.0.0",
-    "@types/bun": "*",
-    "bun": "^1.1.0"
+    "@types/bun": "*"
   },
   "devDependencies": {
     "effect": "workspace:^",

--- a/packages-native/bun-test/package.json
+++ b/packages-native/bun-test/package.json
@@ -36,7 +36,7 @@
     "coverage": "bun test --coverage"
   },
   "peerDependencies": {
-    "effect": "^3.17.9",
+    "effect": ">=3.0.0",
     "@types/bun": "*",
     "bun": "^1.1.0"
   },


### PR DESCRIPTION
This pull request makes a small change to the `@effect-native/bun-test` package by relaxing the peer dependency requirement for `effect` in `package.json`. This allows for greater compatibility with a wider range of `effect` versions.