### PR TITLE
Add copy-lib-to-dist script and update builds

### DIFF
--- a/.changeset/eighty-baboons-drum.md
+++ b/.changeset/eighty-baboons-drum.md
@@ -1,0 +1,6 @@
+---
+"@effect-native/libsqlite": patch
+"@effect-native/libcrsql": patch
+---
+
+unbroke build process to actually include the lib files

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ scratchpad-bun/*
 .idea/
 .env*
 result
+bun.lock

--- a/packages-native/examples-bun/libs/index.ts
+++ b/packages-native/examples-bun/libs/index.ts
@@ -1,0 +1,18 @@
+import { pathToCrSqliteExtension } from "@effect-native/libcrsql"
+import { pathToLibSqlite } from "@effect-native/libsqlite"
+import { Database } from "bun:sqlite"
+
+Database.setCustomSQLite(pathToLibSqlite)
+console.log("Using SQLite library at:", { pathToLibSqlite })
+
+const db = new Database(":memory:")
+console.log("LibSqlite loaded successfully?", db.query("SELECT sqlite_version() AS sqliteVersion").get())
+
+try {
+  console.log("CRSQLite extension works before loading?", db.query("SELECT hex(crsql_site_id()) AS siteId").get())
+} catch (cause) {
+  console.log("CRSQLite extension works before loading?", String(cause))
+}
+db.loadExtension(pathToCrSqliteExtension)
+console.log("Using CRSQLite extension at:", { pathToCrSqliteExtension })
+console.log("CRSQLite extension loaded successfully?", db.query("SELECT hex(crsql_site_id()) AS siteId").get())

--- a/packages-native/examples-bun/libs/package.json
+++ b/packages-native/examples-bun/libs/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "scratchpad-bun-libs",
+  "module": "index.ts",
+  "type": "module",
+  "devDependencies": {
+    "@types/bun": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "@effect-native/bun-test": "file:../../bun-test/dist",
+    "@effect-native/libcrsql": "file:../../libcrsql/dist",
+    "@effect-native/libsqlite": "file:../../libsqlite/dist"
+  }
+}

--- a/packages-native/examples-bun/libs/tsconfig.json
+++ b/packages-native/examples-bun/libs/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    // Enable latest features
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  }
+}

--- a/packages-native/libcrsql/package.json
+++ b/packages-native/libcrsql/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "codegen": "echo '@effect-native/libcrsql: skip codegen'",
     "verify": "tsx scripts/verify-binaries.ts",
-    "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3",
+    "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3 && node ../../scripts/copy-lib-to-dist.mjs",
     "build-esm": "tsc -b tsconfig.build.json",
     "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
     "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",

--- a/packages-native/libsqlite/package.json
+++ b/packages-native/libsqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@effect-native/libsqlite",
-  "version": "3.50.300",
+  "version": "3.50.200",
   "type": "module",
   "license": "MIT",
   "description": "Universal, version-pinned libsqlite3 that Just Works — prebuilt via Nix with per-platform paths.",
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "codegen": "echo '@effect-native/libsqlite: skip codegen'",
-    "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3",
+    "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3 && node ../../scripts/copy-lib-to-dist.mjs",
     "build-esm": "tsc -b tsconfig.build.json",
     "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
     "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",

--- a/scripts/copy-lib-to-dist.mjs
+++ b/scripts/copy-lib-to-dist.mjs
@@ -17,4 +17,3 @@ mkdirSync(resolve(cwd, "dist"), { recursive: true })
 rmSync(dst, { recursive: true, force: true })
 cpSync(src, dst, { recursive: true })
 console.log(`copy-lib-to-dist: copied ${src} -> ${dst}`)
-

--- a/scripts/copy-lib-to-dist.mjs
+++ b/scripts/copy-lib-to-dist.mjs
@@ -6,14 +6,14 @@ import { resolve } from "node:path"
 
 const cwd = process.cwd()
 const src = resolve(cwd, "lib")
-const dst = resolve(cwd, "dist", "lib")
+const dst = resolve(cwd, "dist", "dist", "lib")
 
 if (!existsSync(src)) {
   console.log("copy-lib-to-dist: no lib directory found; skipping")
   process.exit(0)
 }
 
-mkdirSync(resolve(cwd, "dist"), { recursive: true })
+mkdirSync(resolve(cwd, "dist", "dist"), { recursive: true })
 rmSync(dst, { recursive: true, force: true })
 cpSync(src, dst, { recursive: true })
 console.log(`copy-lib-to-dist: copied ${src} -> ${dst}`)

--- a/scripts/copy-lib-to-dist.mjs
+++ b/scripts/copy-lib-to-dist.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/* eslint-env node */
+/* global process, console */
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs"
+import { resolve } from "node:path"
+
+const cwd = process.cwd()
+const src = resolve(cwd, "lib")
+const dst = resolve(cwd, "dist", "lib")
+
+if (!existsSync(src)) {
+  console.log("copy-lib-to-dist: no lib directory found; skipping")
+  process.exit(0)
+}
+
+mkdirSync(resolve(cwd, "dist"), { recursive: true })
+rmSync(dst, { recursive: true, force: true })
+cpSync(src, dst, { recursive: true })
+console.log(`copy-lib-to-dist: copied ${src} -> ${dst}`)
+

--- a/scripts/force-libsqlite-embedded.mjs
+++ b/scripts/force-libsqlite-embedded.mjs
@@ -36,7 +36,10 @@ try {
     const n = Number(m[1])
     if (Math.floor(n / 100) === patch) train.push(n)
   }
-  const max = train.length ? Math.max(...train) : patch * 100 - 1
+  // If there are no published versions for this sqlite patch train yet,
+  // start wrapper patching at 1 (e.g. 3.50.2 -> 3.50.201), not 100.
+  // Using patch*100 ensures next === 1 on first publish for a train.
+  const max = train.length ? Math.max(...train) : patch * 100
   next = (max % 100) + 1
 } catch {
   next = 0


### PR DESCRIPTION
fixes #80 

This pull request introduces a new script to copy the `lib` directory into the build output and updates the build process for both `@effect-native/libsqlite` and `@effect-native/libcrsql` to use this script. It also makes a minor adjustment to the versioning logic for `@effect-native/libsqlite` and corrects its version number.

**Build process improvements:**

* Added a new script, `scripts/copy-lib-to-dist.mjs`, which copies the `lib` directory to `dist/lib` during the build. This ensures that native libraries are included in the package output.
* Updated the `build` script in both `packages-native/libsqlite/package.json` and `packages-native/libcrsql/package.json` to run the new copy script after packaging. [[1]](diffhunk://#diff-4aab6be00b72c1a9b158061fb0582aeeedeeedaada0524bb4b409cbbd6919283L32-R32) [[2]](diffhunk://#diff-aae1ba2fe657fd26cba979d6f18c94652b970bbfe51f5c5b52a5ca741624fabdL33-R33)

**Versioning and packaging fixes:**

* Fixed the version of `@effect-native/libsqlite` in `package.json` from `3.50.300` to `3.50.200` to reflect the correct patch train.
* Adjusted the patch train logic in `scripts/force-libsqlite-embedded.mjs` so that the wrapper patching starts at `1` for new patch trains, ensuring correct versioning on first publish.