### PR TITLE
Cleanup

### DIFF
--- a/.changeset/empty-seas-hide.md
+++ b/.changeset/empty-seas-hide.md
@@ -1,0 +1,6 @@
+---
+"@effect-native/libsqlite": patch
+"@effect-native/libcrsql": patch
+---
+
+README example how to embed and use libsqlite and crsqlite in a compiled Bun single file executable

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,3 +48,7 @@
 /packages/typeclass/ @gcanti
 
 /packages/vitest/ @mikearnaldi
+
+/packages-native/bun-test/ @subtlegradient
+/packages-native/libcrsql/ @subtlegradient
+/packages-native/libsqlite/ @subtlegradient

--- a/packages-native/examples-bun/libs/.gitignore
+++ b/packages-native/examples-bun/libs/.gitignore
@@ -1,0 +1,5 @@
+# compiled single file executable
+index
+
+# exported embedded dependencies
+.lib*

--- a/packages-native/examples-bun/libs/index.ts
+++ b/packages-native/examples-bun/libs/index.ts
@@ -1,9 +1,25 @@
-import { pathToCrSqliteExtension } from "@effect-native/libcrsql"
-import { pathToLibSqlite } from "@effect-native/libsqlite"
+// import { getCrSqliteExtensionPathSync } from "@effect-native/libcrsql"
+// import { getLibSqlitePathSync } from "@effect-native/libsqlite"
+import { getCrSqliteExtensionPathSync } from "@effect-native/libcrsql" with { type: "macro" }
+import { getLibSqlitePathSync } from "@effect-native/libsqlite" with { type: "macro" }
 import { Database } from "bun:sqlite"
 
-Database.setCustomSQLite(pathToLibSqlite)
-console.log("Using SQLite library at:", { pathToLibSqlite })
+async function main() {
+  console.log(
+    "pathToCrSqliteExtension",
+    (await import(getCrSqliteExtensionPathSync(), { assert: { type: "file" } })).default
+  )
+  console.log("pathToLibSqlite", (await import(getLibSqlitePathSync(), { assert: { type: "file" } })).default)
+}
+
+// main().catch((err) => {
+//   console.error(err)
+// })
+
+console.log("embeddedFiles", Bun.embeddedFiles.length, Bun.embeddedFiles.map((it) => it.name))
+
+console.log("Using SQLite library at:", { pathToLibSqlite: getLibSqlitePathSync() })
+Database.setCustomSQLite(getLibSqlitePathSync())
 
 const db = new Database(":memory:")
 console.log("LibSqlite loaded successfully?", db.query("SELECT sqlite_version() AS sqliteVersion").get())
@@ -13,6 +29,6 @@ try {
 } catch (cause) {
   console.log("CRSQLite extension works before loading?", String(cause))
 }
-db.loadExtension(pathToCrSqliteExtension)
-console.log("Using CRSQLite extension at:", { pathToCrSqliteExtension })
+db.loadExtension(getCrSqliteExtensionPathSync())
+console.log("Using CRSQLite extension at:", { pathToCrSqliteExtension: getCrSqliteExtensionPathSync() })
 console.log("CRSQLite extension loaded successfully?", db.query("SELECT hex(crsql_site_id()) AS siteId").get())

--- a/packages-native/examples-bun/libs/index.ts
+++ b/packages-native/examples-bun/libs/index.ts
@@ -3,31 +3,32 @@
 
 import { Database } from "bun:sqlite"
 
-// 1. get the original paths at compile time
 import { getCrSqliteExtensionPathSync } from "@effect-native/libcrsql" with { type: "macro" }
 import { getLibSqlitePathSync } from "@effect-native/libsqlite" with { type: "macro" }
 
-// 2. embed the files so they are included in the compiled binary
-// NOTE: use require to make it synchronous
-const embeddedCrSqliteExtensionPath: string = require(getCrSqliteExtensionPathSync())
-const embeddedLibSqlitePath: string = require(getLibSqlitePathSync())
+const embeddedLibSqlitePath = String(require(getLibSqlitePathSync()))
+const embeddedCrSqliteExtensionPath = String(require(getCrSqliteExtensionPathSync()))
 
-// 3. enable the embedded files to be loaded by writing them out to the filesystem
-// causes bun build to include them in the compiled binary
-const embeddedCrSqliteExtensionFile = Bun.file(embeddedCrSqliteExtensionPath)
-const embeddedLibSqliteFile = Bun.file(embeddedLibSqlitePath)
-
-const exportedCrSqliteExtensionPath = `./.${embeddedCrSqliteExtensionFile.name}`
-const exportedLibSqlitePath = `./.${embeddedLibSqliteFile.name}`
-
-Bun.write(exportedCrSqliteExtensionPath, embeddedCrSqliteExtensionFile)
-Bun.write(exportedLibSqlitePath, embeddedLibSqliteFile)
-
-// 4. use the exported paths at runtime
-Database.setCustomSQLite(exportedLibSqlitePath)
+if (Bun.embeddedFiles.length) {
+  const embeddedLibSqliteFile = Bun.file(embeddedLibSqlitePath)
+  const exportedLibSqlitePath = `./.${embeddedLibSqliteFile.name}`
+  Bun.write(exportedLibSqlitePath, embeddedLibSqliteFile)
+  Database.setCustomSQLite(exportedLibSqlitePath)
+} else {
+  Database.setCustomSQLite(embeddedLibSqlitePath)
+}
 
 const db = new Database(":memory:")
 console.log("LibSqlite loaded successfully?", db.query("SELECT sqlite_version() AS sqliteVersion").get())
 
-db.loadExtension(exportedCrSqliteExtensionPath, "sqlite3_crsqlite_init")
+try {
+  db.loadExtension(embeddedCrSqliteExtensionPath, "sqlite3_crsqlite_init")
+} catch (cause) {
+  if (!String(cause).includes("no such file")) throw cause
+  const embeddedCrSqliteExtensionFile = Bun.file(embeddedCrSqliteExtensionPath)
+  const exportedCrSqliteExtensionPath = `./.${embeddedCrSqliteExtensionFile.name}`
+  Bun.write(exportedCrSqliteExtensionPath, embeddedCrSqliteExtensionFile)
+  db.loadExtension(exportedCrSqliteExtensionPath, "sqlite3_crsqlite_init")
+}
+
 console.log("CRSQLite extension loaded successfully?", db.query("SELECT hex(crsql_site_id()) AS siteId").get())

--- a/packages-native/examples-bun/libs/index.ts
+++ b/packages-native/examples-bun/libs/index.ts
@@ -1,34 +1,33 @@
-// import { getCrSqliteExtensionPathSync } from "@effect-native/libcrsql"
-// import { getLibSqlitePathSync } from "@effect-native/libsqlite"
-import { getCrSqliteExtensionPathSync } from "@effect-native/libcrsql" with { type: "macro" }
-import { getLibSqlitePathSync } from "@effect-native/libsqlite" with { type: "macro" }
+/* eslint-disable @typescript-eslint/no-require-imports */
+// GOAL: embed and use libsqlite and crsqlite in a compiled Bun single file executable
+
 import { Database } from "bun:sqlite"
 
-async function main() {
-  console.log(
-    "pathToCrSqliteExtension",
-    (await import(getCrSqliteExtensionPathSync(), { assert: { type: "file" } })).default
-  )
-  console.log("pathToLibSqlite", (await import(getLibSqlitePathSync(), { assert: { type: "file" } })).default)
-}
+// 1. get the original paths at compile time
+import { getCrSqliteExtensionPathSync } from "@effect-native/libcrsql" with { type: "macro" }
+import { getLibSqlitePathSync } from "@effect-native/libsqlite" with { type: "macro" }
 
-// main().catch((err) => {
-//   console.error(err)
-// })
+// 2. embed the files so they are included in the compiled binary
+// NOTE: use require to make it synchronous
+const embeddedCrSqliteExtensionPath: string = require(getCrSqliteExtensionPathSync())
+const embeddedLibSqlitePath: string = require(getLibSqlitePathSync())
 
-console.log("embeddedFiles", Bun.embeddedFiles.length, Bun.embeddedFiles.map((it) => it.name))
+// 3. enable the embedded files to be loaded by writing them out to the filesystem
+// causes bun build to include them in the compiled binary
+const embeddedCrSqliteExtensionFile = Bun.file(embeddedCrSqliteExtensionPath)
+const embeddedLibSqliteFile = Bun.file(embeddedLibSqlitePath)
 
-console.log("Using SQLite library at:", { pathToLibSqlite: getLibSqlitePathSync() })
-Database.setCustomSQLite(getLibSqlitePathSync())
+const exportedCrSqliteExtensionPath = `./.${embeddedCrSqliteExtensionFile.name}`
+const exportedLibSqlitePath = `./.${embeddedLibSqliteFile.name}`
+
+Bun.write(exportedCrSqliteExtensionPath, embeddedCrSqliteExtensionFile)
+Bun.write(exportedLibSqlitePath, embeddedLibSqliteFile)
+
+// 4. use the exported paths at runtime
+Database.setCustomSQLite(exportedLibSqlitePath)
 
 const db = new Database(":memory:")
 console.log("LibSqlite loaded successfully?", db.query("SELECT sqlite_version() AS sqliteVersion").get())
 
-try {
-  console.log("CRSQLite extension works before loading?", db.query("SELECT hex(crsql_site_id()) AS siteId").get())
-} catch (cause) {
-  console.log("CRSQLite extension works before loading?", String(cause))
-}
-db.loadExtension(getCrSqliteExtensionPathSync())
-console.log("Using CRSQLite extension at:", { pathToCrSqliteExtension: getCrSqliteExtensionPathSync() })
+db.loadExtension(exportedCrSqliteExtensionPath, "sqlite3_crsqlite_init")
 console.log("CRSQLite extension loaded successfully?", db.query("SELECT hex(crsql_site_id()) AS siteId").get())

--- a/packages-native/examples-bun/libs/package.json
+++ b/packages-native/examples-bun/libs/package.json
@@ -12,5 +12,9 @@
     "@effect-native/bun-test": "file:../../bun-test/dist",
     "@effect-native/libcrsql": "file:../../libcrsql/dist",
     "@effect-native/libsqlite": "file:../../libsqlite/dist"
+  },
+  "scripts": {
+    "prebuild-and-run": "cd ../../libcrsql; pnpm build; cd ../libsqlite; pnpm build",
+    "build-and-run": "rm ./index; bun build --target=bun --compile --minify --sourcemap --bytecode . --outfile index && ./index"
   }
 }

--- a/packages-native/examples-bun/libs/package.json
+++ b/packages-native/examples-bun/libs/package.json
@@ -15,6 +15,6 @@
   },
   "scripts": {
     "prebuild-and-run": "cd ../../libcrsql; pnpm build; cd ../libsqlite; pnpm build",
-    "build-and-run": "rm ./index; bun build --target=bun --compile --minify --sourcemap --bytecode . --outfile index && ./index"
+    "build-and-run": "rm ./index *.dylib; bun build --target=bun --compile --minify --sourcemap . --outfile index && ./index"
   }
 }

--- a/packages-native/libcrsql/README.md
+++ b/packages-native/libcrsql/README.md
@@ -24,7 +24,7 @@ db.loadExtension(pathToCrSqliteExtension)
 ## Absolute constants (no side effects)
 
 import { linux_x86_64 } from "@effect-native/libcrsql/paths"
-// linux_x86_64 is an absolute string like 
+// linux_x86_64 is an absolute string like
 // /.../node_modules/@effect-native/libcrsql/lib/linux-x86_64/libcrsqlite.so
 
 ## Effect entrypoint (optional)
@@ -62,4 +62,45 @@ Run a local integrity check to verify bundled binaries match the expected SHA256
 
 ```
 pnpm --filter @effect-native/libcrsql run verify
+```
+
+---
+
+# Example: Embed and use libsqlite and crsqlite in a compiled Bun single file executable
+
+```ts
+/* eslint-disable @typescript-eslint/no-require-imports */
+// GOAL: embed and use libsqlite and crsqlite in a compiled Bun single file executable
+
+import { Database } from "bun:sqlite"
+
+import { getCrSqliteExtensionPathSync } from "@effect-native/libcrsql" with { type: "macro" }
+import { getLibSqlitePathSync } from "@effect-native/libsqlite" with { type: "macro" }
+
+const embeddedLibSqlitePath = String(require(getLibSqlitePathSync()))
+const embeddedCrSqliteExtensionPath = String(require(getCrSqliteExtensionPathSync()))
+
+if (Bun.embeddedFiles.length) {
+  const embeddedLibSqliteFile = Bun.file(embeddedLibSqlitePath)
+  const exportedLibSqlitePath = `./.${embeddedLibSqliteFile.name}`
+  Bun.write(exportedLibSqlitePath, embeddedLibSqliteFile)
+  Database.setCustomSQLite(exportedLibSqlitePath)
+} else {
+  Database.setCustomSQLite(embeddedLibSqlitePath)
+}
+
+const db = new Database(":memory:")
+console.log("LibSqlite loaded successfully?", db.query("SELECT sqlite_version() AS sqliteVersion").get())
+
+try {
+  db.loadExtension(embeddedCrSqliteExtensionPath, "sqlite3_crsqlite_init")
+} catch (cause) {
+  if (!String(cause).includes("no such file")) throw cause
+  const embeddedCrSqliteExtensionFile = Bun.file(embeddedCrSqliteExtensionPath)
+  const exportedCrSqliteExtensionPath = `./.${embeddedCrSqliteExtensionFile.name}`
+  Bun.write(exportedCrSqliteExtensionPath, embeddedCrSqliteExtensionFile)
+  db.loadExtension(exportedCrSqliteExtensionPath, "sqlite3_crsqlite_init")
+}
+
+console.log("CRSQLite extension loaded successfully?", db.query("SELECT hex(crsql_site_id()) AS siteId").get())
 ```

--- a/packages-native/libcrsql/tsconfig.test.json
+++ b/packages-native/libcrsql/tsconfig.test.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["test"],
   "references": [
-    { "path": "tsconfig.src.json" },
-    { "path": "../../packages/vitest/tsconfig.src.json" }
+    { "path": "tsconfig.src.json" }
   ],
   "compilerOptions": {
     "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
@@ -11,4 +10,3 @@
     "noEmit": true
   }
 }
-

--- a/packages-native/libsqlite/README.md
+++ b/packages-native/libsqlite/README.md
@@ -57,3 +57,44 @@ If you'd like musl or Windows support, please open an issue and we'll prioritize
   - Example: SQLite `3.50.2`, first wrapper → `3.50.200`; next wrapper → `3.50.201`.
 - SemVer behavior: normal `^3.50.0` ranges see wrapper updates within the same SQLite minor.
 - Exact SQLite version is recorded in `lib/metadata.json` and surfaced in docs.
+
+---
+
+# Example: Embed and use libsqlite and crsqlite in a compiled Bun single file executable
+
+```ts
+/* eslint-disable @typescript-eslint/no-require-imports */
+// GOAL: embed and use libsqlite and crsqlite in a compiled Bun single file executable
+
+import { Database } from "bun:sqlite"
+
+import { getCrSqliteExtensionPathSync } from "@effect-native/libcrsql" with { type: "macro" }
+import { getLibSqlitePathSync } from "@effect-native/libsqlite" with { type: "macro" }
+
+const embeddedLibSqlitePath = String(require(getLibSqlitePathSync()))
+const embeddedCrSqliteExtensionPath = String(require(getCrSqliteExtensionPathSync()))
+
+if (Bun.embeddedFiles.length) {
+  const embeddedLibSqliteFile = Bun.file(embeddedLibSqlitePath)
+  const exportedLibSqlitePath = `./.${embeddedLibSqliteFile.name}`
+  Bun.write(exportedLibSqlitePath, embeddedLibSqliteFile)
+  Database.setCustomSQLite(exportedLibSqlitePath)
+} else {
+  Database.setCustomSQLite(embeddedLibSqlitePath)
+}
+
+const db = new Database(":memory:")
+console.log("LibSqlite loaded successfully?", db.query("SELECT sqlite_version() AS sqliteVersion").get())
+
+try {
+  db.loadExtension(embeddedCrSqliteExtensionPath, "sqlite3_crsqlite_init")
+} catch (cause) {
+  if (!String(cause).includes("no such file")) throw cause
+  const embeddedCrSqliteExtensionFile = Bun.file(embeddedCrSqliteExtensionPath)
+  const exportedCrSqliteExtensionPath = `./.${embeddedCrSqliteExtensionFile.name}`
+  Bun.write(exportedCrSqliteExtensionPath, embeddedCrSqliteExtensionFile)
+  db.loadExtension(exportedCrSqliteExtensionPath, "sqlite3_crsqlite_init")
+}
+
+console.log("CRSQLite extension loaded successfully?", db.query("SELECT hex(crsql_site_id()) AS siteId").get())
+```

--- a/packages-native/libsqlite/tsconfig.test.json
+++ b/packages-native/libsqlite/tsconfig.test.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["test"],
   "references": [
-    { "path": "tsconfig.src.json" },
-    { "path": "../vitest/tsconfig.src.json" }
+    { "path": "tsconfig.src.json" }
   ],
   "compilerOptions": {
     "types": ["node"],
@@ -12,4 +11,3 @@
     "outDir": "build/test"
   }
 }
-

--- a/scripts/codemod.mjs
+++ b/scripts/codemod.mjs
@@ -5,7 +5,7 @@ import * as Path from "node:path"
 
 // Look up files in all workspace packages including those nested in
 // sub-packages (e.g. `packages/ai/openapi`).
-const pattern = "packages/{*,*/*}/src/**/*.ts"
+const pattern = "packages-native/{*,*/*}/src/**/*.ts"
 
 const paths = Glob.globSync(pattern, {
   ignore: ["**/internal/**"]


### PR DESCRIPTION
This pull request introduces a comprehensive example and supporting changes for embedding and using both `libsqlite` and `crsqlite` in a compiled Bun single-file executable. The changes provide updated documentation, scripts, and code to demonstrate how to bundle and load these native libraries at runtime, including handling Bun's embedded files. Additionally, there are minor improvements to project configuration and ownership.

**Embedding and usage example for Bun single-file executables:**

- Added a complete example in both `libsqlite` and `libcrsql` READMEs showing how to embed and load `libsqlite` and `crsqlite` in a Bun-compiled single-file executable, including handling extraction and dynamic loading at runtime. [[1]](diffhunk://#diff-ca7d1cf566a0f495a7fc06897fd86276a714260925e5e092e85a7cde4c7e33e6R66-R106) [[2]](diffhunk://#diff-2e8a144dc432e9c0a6b6fafcdaf082a3bbe9d6eb75fcc5758cab3953cab546acR60-R100)
- Refactored `packages-native/examples-bun/libs/index.ts` to implement the embedding logic, using macro imports and conditional extraction of embedded files before loading them into `bun:sqlite`.
- Updated `.gitignore` in the example to ignore generated single-file executables and exported dependencies.
- Added scripts to `package.json` to automate building dependencies and compiling the single-file executable.

**Project configuration and ownership:**

- Added ownership for new native packages (`bun-test`, `libcrsql`, `libsqlite`) in `.github/CODEOWNERS`.
- Updated test TypeScript configs to remove unnecessary references. [[1]](diffhunk://#diff-9ac0c69c49cb8c3b393d2d9bf9f1ef0cf0cb91ef9ed699722264e49232c9ead1L5-L14) [[2]](diffhunk://#diff-b6cdd601b476e12d62fc0416f203425574d0c8ca1c470ee21fb98e83839b1602L5-R5) [[3]](diffhunk://#diff-b6cdd601b476e12d62fc0416f203425574d0c8ca1c470ee21fb98e83839b1602L15)

**Miscellaneous:**

- Updated the codemod script to look for source files in `packages-native` instead of `packages`.
- Added a changeset describing the new embedding example and patch releases for both libraries.