### PR TITLE
Ensure effect subpath is published and verified

### DIFF
--- a/.changeset/fix-libcrsql-effect-dist.md
+++ b/.changeset/fix-libcrsql-effect-dist.md
@@ -1,0 +1,10 @@
+---
+"@effect-native/libcrsql": patch
+---
+
+Include the `./effect` subpath in the published build and guard it prepublish.
+
+- Remove `src/effect.ts` from `tsconfig.build.json` exclusions so ESM/CJS/DTS are emitted.
+- Add `scripts/verify-exports.mjs` and wire `prepublishOnly` to build + verify.
+- Prevents `ERR_MODULE_NOT_FOUND` for `@effect-native/libcrsql/effect`.
+

--- a/.changeset/fix-libsqlite-effect-dist.md
+++ b/.changeset/fix-libsqlite-effect-dist.md
@@ -1,0 +1,10 @@
+---
+"@effect-native/libsqlite": patch
+---
+
+Add prepublish verification for the `./effect` subpath artifacts.
+
+- Introduce `scripts/verify-exports.mjs` that checks `dist/dist/{esm,cjs,dts}/effect.*` and attempts an ESM import.
+- Wire `prepublishOnly` to build + verify and whitelist the script in `files`.
+- Prevents publishing a package where `@effect-native/libsqlite/effect` fails to resolve.
+

--- a/packages-native/libcrsql/package.json
+++ b/packages-native/libcrsql/package.json
@@ -31,6 +31,7 @@
     "codegen": "echo '@effect-native/libcrsql: skip codegen'",
     "verify": "tsx scripts/verify-binaries.ts",
     "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3 && node ../../scripts/copy-lib-to-dist.mjs",
+    "prepublishOnly": "pnpm build && node scripts/verify-exports.mjs",
     "build-esm": "tsc -b tsconfig.build.json",
     "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
     "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
@@ -63,6 +64,7 @@
     "dist",
     "src",
     "lib",
+    "scripts/verify-exports.mjs",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"

--- a/packages-native/libcrsql/scripts/verify-exports.mjs
+++ b/packages-native/libcrsql/scripts/verify-exports.mjs
@@ -1,6 +1,8 @@
-import { existsSync, readFileSync } from 'node:fs'
-import { join, dirname } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+/* eslint-env node */
+/* global console, process */
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -9,31 +11,34 @@ const root = dirname(__dirname) // package root
 function assert(cond, msg) {
   if (!cond) {
     console.error(`verify-exports: ${msg}`)
+
     process.exit(1)
   }
 }
 
 // Check dist artifacts exist
 // build-utils pack-v3 nests artifacts under dist/dist/*
-const distEsm = join(root, 'dist/dist/esm/effect.js')
-const distCjs = join(root, 'dist/dist/cjs/effect.js')
-const distDts = join(root, 'dist/dist/dts/effect.d.ts')
+const distEsm = join(root, "dist/dist/esm/effect.js")
+const distCjs = join(root, "dist/dist/cjs/effect.js")
+const distDts = join(root, "dist/dist/dts/effect.d.ts")
 
 assert(existsSync(distEsm), `missing ${distEsm}`)
 assert(existsSync(distCjs), `missing ${distCjs}`)
 assert(existsSync(distDts), `missing ${distDts}`)
 
 // Basic import checks via file URLs to dist dir
-const pkgJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
-assert(pkgJson.exports && pkgJson.exports['./effect'], 'exports["./effect"] not present')
+const pkgJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
+assert(pkgJson.exports && pkgJson.exports["./effect"], "exports[\"./effect\"] not present")
 
-const distUrl = pathToFileURL(join(root, 'dist')).href
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const distUrl = pathToFileURL(join(root, "dist")).href
 
 // Try ESM import by resolving file path directly
 const esmUrl = pathToFileURL(distEsm).href
 await import(esmUrl).catch((e) => {
-  console.error('verify-exports: ESM import failed:', e)
+  console.error("verify-exports: ESM import failed:", e)
+
   process.exit(1)
 })
 
-console.log('verify-exports: OK')
+console.log("verify-exports: OK")

--- a/packages-native/libcrsql/scripts/verify-exports.mjs
+++ b/packages-native/libcrsql/scripts/verify-exports.mjs
@@ -1,6 +1,7 @@
 /* eslint-env node */
 /* global console, process */
 import { existsSync, readFileSync } from "node:fs"
+import { createRequire } from "node:module"
 import { dirname, join } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
@@ -40,5 +41,14 @@ await import(esmUrl).catch((e) => {
 
   process.exit(1)
 })
+
+// Also verify CJS require works
+try {
+  const req = createRequire(import.meta.url)
+  req(distCjs)
+} catch (e) {
+  console.error("verify-exports: CJS require failed:", e)
+  process.exit(1)
+}
 
 console.log("verify-exports: OK")

--- a/packages-native/libcrsql/scripts/verify-exports.mjs
+++ b/packages-native/libcrsql/scripts/verify-exports.mjs
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const root = dirname(__dirname) // package root
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error(`verify-exports: ${msg}`)
+    process.exit(1)
+  }
+}
+
+// Check dist artifacts exist
+// build-utils pack-v3 nests artifacts under dist/dist/*
+const distEsm = join(root, 'dist/dist/esm/effect.js')
+const distCjs = join(root, 'dist/dist/cjs/effect.js')
+const distDts = join(root, 'dist/dist/dts/effect.d.ts')
+
+assert(existsSync(distEsm), `missing ${distEsm}`)
+assert(existsSync(distCjs), `missing ${distCjs}`)
+assert(existsSync(distDts), `missing ${distDts}`)
+
+// Basic import checks via file URLs to dist dir
+const pkgJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
+assert(pkgJson.exports && pkgJson.exports['./effect'], 'exports["./effect"] not present')
+
+const distUrl = pathToFileURL(join(root, 'dist')).href
+
+// Try ESM import by resolving file path directly
+const esmUrl = pathToFileURL(distEsm).href
+await import(esmUrl).catch((e) => {
+  console.error('verify-exports: ESM import failed:', e)
+  process.exit(1)
+})
+
+console.log('verify-exports: OK')

--- a/packages-native/libcrsql/tsconfig.build.json
+++ b/packages-native/libcrsql/tsconfig.build.json
@@ -6,5 +6,5 @@
     "declarationDir": "build/dts",
     "stripInternal": true
   },
-  "exclude": ["src/effect.ts"]
+  "exclude": []
 }

--- a/packages-native/libsqlite/package.json
+++ b/packages-native/libsqlite/package.json
@@ -35,7 +35,8 @@
     "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
     "check": "tsc -b tsconfig.json",
     "test": "vitest",
-    "coverage": "vitest --coverage"
+    "coverage": "vitest --coverage",
+    "prepublishOnly": "pnpm build && node scripts/verify-exports.mjs"
   },
   "peerDependencies": {
     "effect": "*"
@@ -44,5 +45,15 @@
     "effect": {
       "optional": true
     }
-  }
+  },
+  "files": [
+    "build",
+    "dist",
+    "src",
+    "lib",
+    "scripts/verify-exports.mjs",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages-native/libsqlite/scripts/verify-exports.mjs
+++ b/packages-native/libsqlite/scripts/verify-exports.mjs
@@ -1,6 +1,8 @@
-import { existsSync, readFileSync } from 'node:fs'
-import { join, dirname } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+/* eslint-env node */
+/* global console, process */
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -8,23 +10,25 @@ const root = dirname(__dirname)
 
 function fail(msg) {
   console.error(`verify-exports: ${msg}`)
+
   process.exit(1)
 }
 
-const distEsm = join(root, 'dist/dist/esm/effect.js')
-const distCjs = join(root, 'dist/dist/cjs/effect.js')
-const distDts = join(root, 'dist/dist/dts/effect.d.ts')
+const distEsm = join(root, "dist/dist/esm/effect.js")
+const distCjs = join(root, "dist/dist/cjs/effect.js")
+const distDts = join(root, "dist/dist/dts/effect.d.ts")
 
 if (!existsSync(distEsm)) fail(`missing ${distEsm}`)
 if (!existsSync(distCjs)) fail(`missing ${distCjs}`)
 if (!existsSync(distDts)) fail(`missing ${distDts}`)
 
-const pkgJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
-if (!(pkgJson.exports && pkgJson.exports['./effect'])) fail('exports["./effect"] not present')
+const pkgJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
+if (!(pkgJson.exports && pkgJson.exports["./effect"])) fail("exports[\"./effect\"] not present")
 
 await import(pathToFileURL(distEsm).href).catch((e) => {
-  console.error('verify-exports: ESM import failed:', e)
+  console.error("verify-exports: ESM import failed:", e)
+
   process.exit(1)
 })
 
-console.log('verify-exports: OK')
+console.log("verify-exports: OK")

--- a/packages-native/libsqlite/scripts/verify-exports.mjs
+++ b/packages-native/libsqlite/scripts/verify-exports.mjs
@@ -1,0 +1,30 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const root = dirname(__dirname)
+
+function fail(msg) {
+  console.error(`verify-exports: ${msg}`)
+  process.exit(1)
+}
+
+const distEsm = join(root, 'dist/dist/esm/effect.js')
+const distCjs = join(root, 'dist/dist/cjs/effect.js')
+const distDts = join(root, 'dist/dist/dts/effect.d.ts')
+
+if (!existsSync(distEsm)) fail(`missing ${distEsm}`)
+if (!existsSync(distCjs)) fail(`missing ${distCjs}`)
+if (!existsSync(distDts)) fail(`missing ${distDts}`)
+
+const pkgJson = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
+if (!(pkgJson.exports && pkgJson.exports['./effect'])) fail('exports["./effect"] not present')
+
+await import(pathToFileURL(distEsm).href).catch((e) => {
+  console.error('verify-exports: ESM import failed:', e)
+  process.exit(1)
+})
+
+console.log('verify-exports: OK')

--- a/packages-native/libsqlite/scripts/verify-exports.mjs
+++ b/packages-native/libsqlite/scripts/verify-exports.mjs
@@ -8,22 +8,29 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const root = dirname(__dirname)
 
-function fail(msg) {
-  console.error(`verify-exports: ${msg}`)
+function assert(cond, msg) {
+  if (!cond) {
+    console.error(`verify-exports: ${msg}`)
 
-  process.exit(1)
+    process.exit(1)
+  }
 }
 
 const distEsm = join(root, "dist/dist/esm/effect.js")
 const distCjs = join(root, "dist/dist/cjs/effect.js")
 const distDts = join(root, "dist/dist/dts/effect.d.ts")
 
-if (!existsSync(distEsm)) fail(`missing ${distEsm}`)
-if (!existsSync(distCjs)) fail(`missing ${distCjs}`)
-if (!existsSync(distDts)) fail(`missing ${distDts}`)
+assert(existsSync(distEsm), `missing ${distEsm}`)
+assert(existsSync(distCjs), `missing ${distCjs}`)
+assert(existsSync(distDts), `missing ${distDts}`)
 
-const pkgJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
-if (!(pkgJson.exports && pkgJson.exports["./effect"])) fail("exports[\"./effect\"] not present")
+let pkgJson
+try {
+  pkgJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"))
+} catch (e) {
+  assert(false, `failed to read/parse package.json: ${e?.message ?? e}`)
+}
+assert(pkgJson.exports && pkgJson.exports["./effect"], "exports[\"./effect\"] not present")
 
 await import(pathToFileURL(distEsm).href).catch((e) => {
   console.error("verify-exports: ESM import failed:", e)

--- a/packages-native/libsqlite/scripts/verify-exports.mjs
+++ b/packages-native/libsqlite/scripts/verify-exports.mjs
@@ -1,6 +1,7 @@
 /* eslint-env node */
 /* global console, process */
 import { existsSync, readFileSync } from "node:fs"
+import { createRequire } from "node:module"
 import { dirname, join } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
@@ -37,5 +38,14 @@ await import(pathToFileURL(distEsm).href).catch((e) => {
 
   process.exit(1)
 })
+
+// Also verify CJS require works
+try {
+  const req = createRequire(import.meta.url)
+  req(distCjs)
+} catch (e) {
+  console.error("verify-exports: CJS require failed:", e)
+  process.exit(1)
+}
 
 console.log("verify-exports: OK")


### PR DESCRIPTION
This pull request improves the reliability of publishing the `@effect-native/libcrsql` and `@effect-native/libsqlite` packages by ensuring their `./effect` subpaths are correctly built and verified before publishing. The main changes add prepublish verification scripts that check for the presence and correctness of build artifacts, helping prevent broken subpath exports.

**Prepublish verification and build improvements:**

* Added `scripts/verify-exports.mjs` to both `libcrsql` and `libsqlite` packages. These scripts check that `dist/dist/{esm,cjs,dts}/effect.*` files exist, verify the `./effect` export in `package.json`, and attempt an ESM import to ensure the build is valid. [[1]](diffhunk://#diff-c94ae74167bc5407d0167bafece1caffda83cc2d82c32fe06eb7bcbaf2cd80f3R1-R39) [[2]](diffhunk://#diff-045f4835bfd15d1f0847532f3e4dc7decce272775d8ff4e3eba0d4e6f177b6adR1-R30)
* Wired the new verification scripts to the `prepublishOnly` lifecycle in both `libcrsql/package.json` and `libsqlite/package.json`, so publishing is blocked if verification fails. [[1]](diffhunk://#diff-aae1ba2fe657fd26cba979d6f18c94652b970bbfe51f5c5b52a5ca741624fabdR34) [[2]](diffhunk://#diff-4aab6be00b72c1a9b158061fb0582aeeedeeedaada0524bb4b409cbbd6919283L38-R39)
* Updated the `files` array in both packages to whitelist the verification script, ensuring it is included in the published package. [[1]](diffhunk://#diff-aae1ba2fe657fd26cba979d6f18c94652b970bbfe51f5c5b52a5ca741624fabdR67) [[2]](diffhunk://#diff-4aab6be00b72c1a9b158061fb0582aeeedeeedaada0524bb4b409cbbd6919283L47-R58)

**Build configuration fixes:**

* Removed `src/effect.ts` from the `exclude` array in `libcrsql/tsconfig.build.json`, so ESM, CJS, and DTS artifacts for the `effect` subpath are emitted during build.

**Documentation and changelog:**

* Added changeset entries documenting these fixes and their impact on preventing `ERR_MODULE_NOT_FOUND` for the `./effect` subpath. [[1]](diffhunk://#diff-95522d641a0577c2643d48fc6ac2265923948e90baeb555346f61a72b91c2906R1-R10) [[2]](diffhunk://#diff-821ef9aae739737c5e0e009a6918a1de8f08f2861c544c17e1ba5ec9c4abaff2R1-R10)