### PR TITLE
chore: use npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         uses: ./.github/actions/setup
+      - name: Setup Node for npm provenance
+        uses: actions/setup-node@v4
+        with:
+          node-version: 23.7.0
+          registry-url: https://registry.npmjs.org
       - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
@@ -29,4 +34,4 @@ jobs:
           publish: pnpm changeset-publish
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- configure release workflow to publish to npm using OIDC provenance

## Testing
- `nix develop --command pnpm ok`


------
https://chatgpt.com/codex/tasks/task_e_68bf735e96f4832fb96899523ebf6c37