### PR TITLE
feat: add @effect-native/render service and DOM driver

### DIFF
--- a/.specs/render-service/design.md
+++ b/.specs/render-service/design.md
@@ -1,0 +1,156 @@
+# Render Service — Phase 3 Design
+
+## Effect Library Patterns
+
+- Use `Effect.gen` generators to orchestrate render sessions, ensuring each render call is modeled as an Effect that updates the mounted tree.
+- Wrap React root creation within `Scope.extend` to tie lifecycle to Effect scopes; renders happen inside scoped regions to enable auto-unmount on scope exit/interruption.
+- Provide service APIs via `Context.Tag<typeof Render>` and Layers (`Render.layerDom`, `Render.layerNative`) built from driver constructors that run inside `Effect.gen`.
+- Employ `Effect.async` to bridge React events back into Effect, resuming the waiting fiber via callback triggers while preserving interruption semantics.
+- Use `Channel` / `Stream` integration for streaming updates: `Render.stream` consumes `Stream<ReactNode>` and sequentially renders values.
+
+## Type Safety Approach
+
+- Use discriminated union error types defined via `Data.TaggedError` (e.g., `RenderDriverUnavailable`, `RenderRootNotFound`).
+- Define `RenderRoot<TRenderer>` generic to encode renderer-specific metadata (DOM container vs Native app key) without `any`.
+- Provide typed event adapters: `Render.event<Event, E, A>(handler: (event: Event) => Effect<A, E>)` returns a React callback typed as `(event: Event) => void` but ensures the handler returns typed Effect.
+- Avoid type assertions by modeling driver interfaces precisely, e.g., `interface RenderDriver<RNode> { readonly makeRoot: ... }`.
+
+## Module Architecture
+
+```
+packages/render/
+  src/
+    Render.ts (public service interface + Layer combinators)
+    Driver.ts (driver interface + constructors)
+    drivers/
+      dom.ts (React DOM implementation)
+      native.ts (React Native implementation)
+    internal/
+      RootManager.ts (scoped root registry)
+      EventBridge.ts (Effect-aware callback wrappers)
+      StreamRenderer.ts (consumes streams)
+  demos/
+    dom-basic/
+    native-basic/
+  test/
+    render.spec.ts
+    dom.spec.ts
+    native.spec.ts
+```
+
+- `Render.ts` exports `Render` context tag, `RenderService` interface, `render`, `withRoot`, `stream`, `event` helpers.
+- `Driver.ts` defines driver contract and implements factory functions returning Layers.
+- Internal modules handle resource management (scoped registries with `Effect.Ref` or `Effect.Scope`).
+- Demo apps live under `packages/render/demos/` to keep them close to service.
+
+## Error Handling Strategy
+
+- All driver operations run inside `Effect.gen`; errors thrown by React APIs (e.g., invalid container) captured and wrapped in typed errors via `yield* new RenderDriverError({ cause })`.
+- Interruption handling: register finalizers on scopes to call `root.unmount()` or `AppRegistry.unmountApplicationComponentAtRootTag`.
+- Event handlers propagate errors by failing the awaiting effect; optionally provide `Render.eventSync` for fire-and-forget.
+- Provide `Render.onError` hook in driver configuration to log errors and optionally rethrow.
+
+## Testing Strategy
+
+- Unit tests with `@effect/vitest` verifying `render` updates DOM using React Testing Library (JSDOM environment) and ensures repeated renders update existing nodes.
+- Use TestClock to simulate asynchronous flows (delayed fetch) and assert multi-step rendering.
+- React Native tests run with `react-native-testing-library` in Jest environment, verifying event bridging and unmount.
+- Stream tests create `Stream.fromIterable` of React elements and verify sequential renders occur.
+- Stress/integration tests simulate interruptions by forking an effect, rendering UI, then interrupting fiber and asserting unmount.
+
+## JSDoc Documentation Plan
+
+- Document `Render` service with `@category Services` and provide `@example` sections for DOM + React Native usage.
+- Provide `@example` for streaming demo: `yield* Render.stream(Stream.make(...))`.
+- Document driver configuration options (container, root component, transitions) with inline types.
+- Ensure docgen references compile by using actual exported helpers in examples.
+
+## Code Examples
+
+```ts
+import { Effect, Layer } from "effect";
+import { Render } from "@effect-native/render";
+import { domLayer } from "@effect-native/render/dom";
+import { createRootContainer } from "./dom/roots";
+
+const program = Effect.gen(function* () {
+  const { render, withRoot, event } = yield* Render;
+  const root = yield* withRoot({ container: createRootContainer("app") });
+
+  yield* render(root, <Status text="Loading…" />);
+
+  const data = yield* fetchUserProfile;
+
+  const onRefresh = event((evt: React.MouseEvent<HTMLButtonElement>) =>
+    Effect.gen(function* () {
+      yield* logDebug({ type: "refresh", x: evt.clientX });
+      yield* render(root, <Status text="Refreshing…" />);
+    })
+  );
+
+  yield* render(
+    root,
+    <ProfileView data={data} onRefresh={onRefresh} />
+  );
+
+  const next = yield* waitFor(onRefresh);
+  yield* render(root, <Status text={`Refreshed at ${next}`} />);
+});
+
+program.pipe(Effect.provide(domLayer({ container: document.getElementById("app")! })), Effect.runFork);
+```
+
+### Stream Example
+
+```ts
+yield* Render.stream(root, Stream.fromIterable([
+  <Status key="loading" text="Loading" />,
+  <Status key="ready" text="Ready" />
+]));
+```
+
+### React Native Demo Snippet
+
+```ts
+const nativeLayer = Render.layerNative({
+  appKey: "EffectDemo",
+  component: RootComponent,
+});
+
+const nativeProgram = Effect.gen(function* () {
+  const { render, withRoot, event } = yield* Render;
+  const root = yield* withRoot({ component: <Root /> });
+  yield* render(root, <AppScreen status="Booting" />);
+
+  const result = yield* fetchFromNetwork;
+  yield* render(root, <AppScreen status={result.status} />);
+});
+```
+
+## Integration Points
+
+- Provide `Render.layerTest` returning a deterministic in-memory driver for unit tests.
+- Expose adapters for `Effect.Stream`, `PubSub`, and `SubscriptionRef` to push updates.
+- Logging integration via `Logger` service: drivers accept logger for lifecycle events.
+- Interop with `Scope` ensures compatibility with other services that use scoped resources (e.g., database connections that update UI when ready).
+- Provide React context provider for hooking into effect-managed state if needed.
+
+## Demos
+
+1. **DOM Loading/Data Demo**
+   - Tooling: Vite + SWC bundler, React 18.
+   - Flow: render "Loading", wait 1s, fetch JSON from mock API, render data table, allow button to trigger re-fetch using `Render.event`.
+   - Validates FR1.2, FR1.4, FR1.5 (by interrupt test hooking to UI close button).
+
+2. **DOM Streamed Search Demo**
+   - Uses `Render.stream` to live-update search results as user types, bridging `SubscriptionRef` to React input value.
+   - Showcases low-latency updates and event bridging to `Effect.debounce`.
+
+3. **React Native Counter Demo (Expo)**
+   - Render initial count, button increments by bridging events.
+   - Demonstrates multi-render flow and ensures unmount when effect stops (closing app stops effect fiber).
+
+4. **Interruption Stress Demo**
+   - CLI script using DOM driver in JSDOM to render 100 updates, then interrupt mid-stream, verifying cleanup instrumentation logs.
+
+Each demo includes README with setup, `pnpm demo:<name>` script, and instrumentation metrics.

--- a/.specs/render-service/instructions.md
+++ b/.specs/render-service/instructions.md
@@ -1,0 +1,71 @@
+# Render Service — Phase 1 Instructions
+
+## Overview and User Story
+
+Build an Effect-native Render service that lets Effect programs drive React component trees imperatively from within `Effect.gen` generators. The service should expose a render function that can be yielded multiple times, allowing Effect workflows to stream UI updates (loading → data, error recovery, etc.) without leaving the Effect runtime. Inputs (props, event callbacks, async data) should round-trip through Effect effects, giving developers a unified concurrency and resource management model while reusing familiar React component ecosystems.
+
+Primary user story:
+- As an Effect developer building cross-platform apps, I want to yield React renders directly inside my Effect generators so I can orchestrate asynchronous flows (fetch → optimistic UI → resolved UI) without React-specific hooks, while still leveraging the React renderer for DOM / Native output.
+
+## Core Requirements
+
+- Provide an Effect Service (Layer + Context) exposing a `render` function that can be yielded in generators. The render function should accept a React element tree and optional options (target root, key, transitions) and return the rendered result handle.
+- Support multi-step rendering within a single Effect: repeated `yield* Render.render(<UI />)` calls should update the mounted tree without remounting or leaking resources.
+- Event callbacks passed as props must integrate with Effect: the service should wrap callbacks so that invocations resume the originating Effect fiber with typed event payloads.
+- Provide cancellable rendering: interrupting the calling Effect should tear down the React tree, dispose listeners, and release resources cleanly.
+- Support at least two renderers in v1:
+  - Web (React DOM via `react-dom/client`)
+  - React Native (using `react-native` or `react-native-renderer` adapter)
+- Support hydration / server handoff as future consideration but not v1 requirement.
+- Provide ergonomic options for running render loops (e.g., `Render.withRoot`, `Render.portals`, etc.) while remaining renderer-agnostic.
+- Deliver clear DX: strongly typed API, JSDoc examples, compatibility notes, error taxonomy.
+
+## Technical Specifications
+
+- Package name: `@effect-native/render` (new workspace package).
+- Target React 18.3+ concurrent APIs (`createRoot`, `startTransition`).
+- Provide platform-specific drivers (DOM, Native) behind an Effect-managed abstraction, selected via environment-specific Layer composition.
+- Compose with `effect/Layer` for dependency injection: e.g., `Render.layer(RenderDriver.dom({ container }))`.
+- The render API must be re-entrant and safe under concurrent usage: multiple fibers should be able to render to independent roots simultaneously.
+- Provide typed event channel bridging React synthetic/native events to Effect: e.g., `Render.event<T>(handler: (event: T) => Effect<...>)`.
+- Ensure compatibility with SSR contexts: allow injection of custom renderer (No-op) for testing.
+- Provide integration points for streaming data (maybe `Render.stream` bridging to `Effect.Stream`?).
+
+## Acceptance Criteria
+
+- API allows an Effect generator to render loading / success states sequentially without remount flicker on both DOM and React Native sample apps.
+- Event callback bridging demonstrably works: a demo effect can await a button click (DOM) and update UI accordingly.
+- Interruption cleans up renders: tests confirm that cancelling the effect unmounts the React tree.
+- Provide documentation covering setup, usage patterns, and demos for DOM + React Native.
+- Works with repository lint/typecheck/docgen/test suites.
+
+## Out of Scope
+
+- Building a fully featured router or state management library.
+- Implementing SSR or server components (hydration can be deferred).
+- Custom renderer creation beyond DOM and React Native drivers.
+- Backwards compatibility with React < 18.
+- Non-React UI frameworks (Solid, Vue, etc.).
+
+## Success Metrics
+
+- Demo apps (DOM + React Native) show <16ms render latency for successive updates in common cases.
+- Event bridging introduces <1 microtask overhead relative to direct React callback (measured in demos/tests).
+- Zero leaked React roots in stress tests (tracked via driver instrumentation).
+- Positive developer feedback: Example code copy-paste works with minimal configuration.
+
+## Future Considerations
+
+- Support React Server Components / SSR hydration to allow seamless server/client transitions.
+- Add integration with streaming sources (`Effect.Stream`, `Channel`) for incremental UI updates.
+- Provide developer tools (DevTools integration, logging, instrumentation).
+- Extend to VR/AR or custom renderers through adapter interface.
+- Add compatibility layers for frameworks (Next.js, Expo) via pre-built Layers.
+
+## Testing Requirements
+
+- Unit tests for driver lifecycle (mount, update, unmount) and event bridging.
+- Integration tests using React Testing Library / React Native Testing Library to assert multi-step renders.
+- Stress tests to simulate rapid updates and interruptions.
+- Docgen tests to ensure API examples compile.
+- Demos executed during CI smoke tests (if feasible) or documented manual verification steps.

--- a/.specs/render-service/plan.md
+++ b/.specs/render-service/plan.md
@@ -1,0 +1,85 @@
+# Render Service — Phase 4 Plan
+
+## 5-Phase Implementation Structure
+
+- [ ] **Phase A — Foundations**
+  - [ ] Scaffold `@effect-native/render` package (tsconfig, entrypoints, build scripts).
+  - [ ] Define `RenderService` interface, Context tag, and driver contract skeletons.
+  - [ ] Establish DOM + Native driver stubs with TODO runtime errors.
+- [ ] **Phase B — DOM Driver MVP**
+  - [ ] Implement DOM root management (`createRoot`, update, unmount) with scoped lifecycle.
+  - [ ] Implement `render`, `withRoot`, and typed event adapters for DOM renderer.
+  - [ ] Add React Testing Library coverage for multi-step renders and event bridging.
+- [ ] **Phase C — Native Driver MVP**
+  - [ ] Implement React Native driver using `AppRegistry` and `renderApplication` APIs.
+  - [ ] Support event adapters and cleanup semantics mirrored from DOM driver.
+  - [ ] Add Jest/React Native Testing Library coverage.
+- [ ] **Phase D — Streaming + Utilities**
+  - [ ] Implement `Render.stream`, `Render.subscribe` (PubSub integration), instrumentation hooks.
+  - [ ] Add stress tests covering interruption, concurrency, and cleanup logging.
+  - [ ] Polish error taxonomy and logging integration.
+- [ ] **Phase E — Documentation & Demos**
+  - [ ] Write comprehensive README + API docs with JSDoc examples.
+  - [ ] Build DOM Loading/Data demo and DOM Streamed Search demo (Vite scripts).
+  - [ ] Build React Native Counter demo (Expo config) and CLI interruption stress script.
+  - [ ] Ensure `pnpm docgen`, `pnpm lint`, `pnpm check`, `pnpm test`, and demo scripts succeed.
+
+## Task Hierarchies & Objectives
+
+### Core Service Development
+- Objective: Provide stable, typed render service bridging Effect ↔ React.
+  - Task Group 1: Context + Driver contracts
+    - Create `Render.ts`, `Driver.ts`, typed error modules.
+    - Define `Render.layer` helpers for plugging drivers into Layers.
+  - Task Group 2: DOM driver implementation
+    - Manage DOM containers, reuse root between renders, ensure cleanup.
+    - Provide event bridging and transitional updates (optionally `startTransition`).
+  - Task Group 3: React Native driver implementation
+    - Manage `AppRegistry` registration/unregistration.
+    - Provide bridging for native events/props.
+
+### Utilities & Streaming
+- Objective: Enable advanced flows (streams, concurrency, instrumentation).
+  - Implement `StreamRenderer` using `Effect.Stream.runForEach`.
+  - Provide `Render.eventChannel` returning `Channel` for event consumption.
+  - Instrument root manager with counters and optional logger integration.
+
+### Documentation & Demos
+- Objective: Deliver developer-ready guidance and proof of viability.
+  - Author README with usage matrix, configuration, and integration notes.
+  - Create `demos/dom-loading` (Vite) and `demos/dom-search` (Vite) with instructions + scripts.
+  - Create `demos/native-counter` (Expo) and `demos/interrupt` (Node CLI) verifying cleanup metrics.
+  - Document manual validation checklists for each demo.
+
+## Validation Checkpoints
+
+- `pnpm lint packages/render` after each module milestone.
+- `pnpm check packages/render` to ensure type safety.
+- `pnpm docgen --filter @effect-native/render` verifying JSDoc examples compile.
+- Targeted tests:
+  - DOM: `pnpm test packages/render/test/dom.spec.ts`
+  - Native: `pnpm test packages/render/test/native.spec.ts`
+  - Streams: `pnpm test packages/render/test/render.spec.ts`
+- Demo scripts: `pnpm demo:render:dom-loading`, `pnpm demo:render:native-counter`, `pnpm demo:render:interrupt`.
+
+## Risk Mitigation Strategies
+
+- React Native environment complexity → use Expo-managed workflow, provide fallback instructions for bare React Native.
+- Concurrent renders causing stale roots → maintain scoped registry keyed by container/appKey with reference counting.
+- Event handler memory leaks → ensure event wrappers capture minimal state and register finalizers for cleanup on unmount.
+- Type-level regressions → adopt `@ts-expect-error` tests verifying compile-time failures when misuse occurs.
+- Demo drift → automate smoke tests invoking demos in CI (headless DOM, mocked Native) to detect breakage early.
+
+## Success Criteria Validation
+
+- Cross-reference FR1.x requirements with tasks: DOM/Native driver tasks satisfy FR1.1–FR1.7; streaming tasks satisfy FR1.8; asynchronous props handled via `withRoot` pipeline.
+- Performance metric (<16ms) validated via React Profiler measurements recorded in demo READMEs.
+- Cleanup verified by instrumentation logs asserting zero active roots after interruption tests.
+- Documentation check: docgen + README + demo READMEs reviewed before release.
+
+## Progress Tracking System
+
+- Maintain `STATUS.md` inside package with checklist mirroring plan, updated per commit.
+- Use commit message prefixes (`feat(render)`, `test(render)`, `docs(render)`) to categorize progress.
+- Add GitHub Project cards for each phase/deliverable, linking to spec sections for traceability.
+- Record demo metrics (latency, event round-trip time) in `demos/REPORT.md` for historical tracking.

--- a/.specs/render-service/requirements.md
+++ b/.specs/render-service/requirements.md
@@ -1,0 +1,62 @@
+# Render Service — Phase 2 Requirements
+
+## Functional Requirements (FR1.x)
+
+- **FR1.1** The service MUST expose an Effect Context tag (`Render`) with a `render` function returning an `Effect` that performs a React render against a mounted root.
+- **FR1.2** The service MUST allow multiple sequential `render` calls within the same fiber to update the same React tree without remounting.
+- **FR1.3** The service MUST expose helper APIs for mounting and disposing render roots (`withRoot`, `makeRoot`) that wrap renderer-specific lifecycle management.
+- **FR1.4** The service MUST adapt React event callbacks into Effect handlers that resume the originating fiber, including error propagation through Effect failure channels.
+- **FR1.5** The service MUST propagate fiber interruption to React unmount, guaranteeing that cancelling the calling Effect tears down the UI and cleans up resources.
+- **FR1.6** The service MUST surface renderer-specific drivers so applications can choose DOM vs React Native at Layer composition time.
+- **FR1.7** The service MUST support running multiple independent render roots simultaneously (e.g., multiple DOM containers, multiple React Native root components).
+- **FR1.8** The service MUST provide convenience helpers for streaming data to UI (e.g., bridging from `Effect.Stream` or `SubscriptionRef`).
+- **FR1.9** The service MUST allow passing asynchronous props (Effects returning values) that are awaited before render, enabling `yield* render(<Component data={yield* fetch} />)` semantics.
+- **FR1.10** The service MUST offer typed error classes (e.g., `RenderRootError`, `RenderDriverUnavailableError`) for predictable failure handling.
+
+## Non-Functional Requirements (NFR2.x)
+
+- **NFR2.1** The API MUST be fully typed with zero `any` usage and no unsafe assertions.
+- **NFR2.2** The service MUST maintain stable render performance with <16ms median update time in provided demos under typical workloads.
+- **NFR2.3** The implementation MUST be platform-agnostic, enabling addition of new renderer drivers without modifying core logic.
+- **NFR2.4** The public API MUST include comprehensive JSDoc with runnable examples validated by docgen.
+- **NFR2.5** The package MUST comply with repository tooling: lint, typecheck, docgen, and tests must pass.
+- **NFR2.6** The service MUST be resilient to concurrent renders from multiple fibers, avoiding race conditions and ensuring thread safety via Effect primitives.
+- **NFR2.7** The design MUST avoid React-specific global state (no singletons that prevent multiple React versions in the same process).
+
+## Technical Constraints (TC3.x)
+
+- **TC3.1** React version MUST be 18.3 or higher, using concurrent rendering APIs (`createRoot`).
+- **TC3.2** The service MUST NOT rely on DOM-specific APIs in core modules; DOM APIs must live in DOM driver implementations.
+- **TC3.3** React Native integration MUST rely on officially supported APIs (e.g., `AppRegistry`, `renderApplication`) without private module imports.
+- **TC3.4** The implementation MUST remain ESM-first and compatible with Node 18+/Bun targets per repository standard.
+- **TC3.5** No side effects during module evaluation besides Context tag definitions; render roots must be created lazily via Effects.
+- **TC3.6** The service MUST preserve Effect's structured concurrency semantics—no manual `Promise` usage outside `Effect.async` wrappers.
+
+## Data Requirements (DR4.x)
+
+- **DR4.1** The service MUST manage internal state describing mounted roots (IDs, containers, cleanup actions) stored in managed refs/scopes.
+- **DR4.2** Event payloads MUST be typed generically, allowing bridging of DOM events, React Native gestures, and custom objects.
+- **DR4.3** Telemetry/diagnostic hooks (if implemented) MUST emit structured data (JSON-serializable objects) for logging and devtools.
+- **DR4.4** Demo applications MUST include sample data flows (e.g., asynchronous fetch results) stored in typed models for clarity.
+
+## Integration Requirements (IR5.x)
+
+- **IR5.1** The Render service MUST integrate with existing Effect Layer composition; e.g., `Render.layerDom` should compose with other layers in an application environment.
+- **IR5.2** The service MUST interoperate with `effect/Scope` for lifecycle management, automatically releasing resources when the scope ends.
+- **IR5.3** Event bridging MUST integrate with `Effect.Channel`/`Stream` where appropriate, enabling consumption via streaming APIs.
+- **IR5.4** Demo apps MUST integrate with bundlers/build tools typical for DOM (Vite) and React Native (Expo/Metro) to validate feasibility.
+
+## Dependencies (DEP6.x)
+
+- **DEP6.1** External dependencies limited to `react`, `react-dom`, `react-native` (and type packages) plus existing Effect libraries.
+- **DEP6.2** Development/test dependencies may include React Testing Library, React Native Testing Library, and @testing-library/jest-native.
+- **DEP6.3** The service MUST leverage existing repository utilities for logging, scheduling, and concurrency if available.
+- **DEP6.4** Demo applications MAY depend on bundler/tooling packages but should remain minimal.
+
+## Success Criteria (SC7.x)
+
+- **SC7.1** Specification acceptance when requirements documentation, design, and plan are approved and demos outlined.
+- **SC7.2** Implementation acceptance when demos run successfully, automated tests pass, and documentation published.
+- **SC7.3** Developer happiness measured by ability to copy-paste demo code into a new project with minimal setup (<5 steps).
+- **SC7.4** Observability: instrumentation surfaces mount/update/unmount counts in logs for debugging.
+- **SC7.5** Clean teardown confirmed by memory usage snapshots before/after long-running demos (no growth beyond 5%).

--- a/packages-native/render/package.json
+++ b/packages-native/render/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@effect-native/render",
+  "version": "0.0.1",
+  "type": "module",
+  "license": "MIT",
+  "description": "Render React component trees from Effect generators.",
+  "homepage": "https://github.com/effect-native/effect-native",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/effect-native/effect-native.git",
+    "directory": "packages-native/render"
+  },
+  "bugs": {
+    "url": "https://github.com/effect-native/effect-native/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "directory": "dist",
+    "linkDirectory": false
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./internal/*": null
+  },
+  "scripts": {
+    "codegen": "echo '@effect-native/render: skip codegen'",
+    "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3",
+    "build-esm": "tsc -b tsconfig.build.json",
+    "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
+    "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest --coverage"
+  },
+  "peerDependencies": {
+    "effect": "workspace:^",
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.5",
+    "effect": "workspace:^",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "jsdom": "^24.1.3"
+  }
+}

--- a/packages-native/render/src/Driver.ts
+++ b/packages-native/render/src/Driver.ts
@@ -1,0 +1,16 @@
+import type * as Effect from "effect/Effect"
+import type * as Scope from "effect/Scope"
+import type { ReactNode } from "react"
+
+export interface RenderDriver<Options, Root, E = never, R = never> {
+  readonly make: (options: Options) => Effect.Effect<Root, E, Scope.Scope | R>
+  readonly render: (root: Root, element: ReactNode) => Effect.Effect<void, E, R>
+}
+
+export declare namespace RenderDriver {
+  export type Any = RenderDriver<any, any, any, any>
+  export type Options<D extends Any> = D extends RenderDriver<infer Options, any, any, any> ? Options : never
+  export type Root<D extends Any> = D extends RenderDriver<any, infer Root, any, any> ? Root : never
+  export type Error<D extends Any> = D extends RenderDriver<any, any, infer E, any> ? E : never
+  export type Environment<D extends Any> = D extends RenderDriver<any, any, any, infer R> ? R : never
+}

--- a/packages-native/render/src/Render.ts
+++ b/packages-native/render/src/Render.ts
@@ -1,0 +1,63 @@
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import { pipe } from "effect/Function"
+import * as Layer from "effect/Layer"
+import * as Runtime from "effect/Runtime"
+import * as Scope from "effect/Scope"
+import type { ReactNode } from "react"
+import type { RenderDriver } from "./Driver.js"
+
+export interface Render<Driver extends RenderDriver.Any = RenderDriver.Any> {
+  readonly driver: Driver
+  readonly withRoot: (
+    options: RenderDriver.Options<Driver>
+  ) => Effect.Effect<
+    RenderDriver.Root<Driver>,
+    RenderDriver.Error<Driver>,
+    Scope.Scope | RenderDriver.Environment<Driver>
+  >
+  readonly render: (
+    root: RenderDriver.Root<Driver>,
+    element: ReactNode
+  ) => Effect.Effect<
+    void,
+    RenderDriver.Error<Driver>,
+    RenderDriver.Environment<Driver>
+  >
+  readonly event: <Event, E = never, R = never>(
+    handler: (event: Event) => Effect.Effect<void, E, R>
+  ) => (event: Event) => void
+}
+
+export const RenderTag: Context.Tag<Render, Render> = Context.GenericTag<Render>(
+  "@effect-native/render/Render"
+)
+
+export const layer = <Driver extends RenderDriver.Any>(
+  driver: Driver
+): Layer.Layer<Render<Driver>> =>
+  Layer.scoped(
+    RenderTag,
+    Effect.gen(function*() {
+      const runtime = (yield* Effect.runtime<RenderDriver.Environment<Driver> | Scope.Scope>()).pipe(
+        Runtime.updateContext(Context.omit(Scope.Scope))
+      ) as Runtime.Runtime<RenderDriver.Environment<Driver>>
+      const runFork = Runtime.runFork(runtime)
+
+      return {
+        driver,
+        withRoot: (options) =>
+          Effect.gen(function*() {
+            const scope = yield* Scope.Scope
+            return yield* pipe(
+              driver.make(options),
+              Scope.extend(scope)
+            )
+          }),
+        render: (root, element) => driver.render(root, element),
+        event: (handler) => (event) => {
+          runFork(handler(event))
+        }
+      } satisfies Render<Driver>
+    })
+  )

--- a/packages-native/render/src/dom.ts
+++ b/packages-native/render/src/dom.ts
@@ -1,0 +1,39 @@
+import * as Effect from "effect/Effect"
+import { flushSync } from "react-dom"
+import { createRoot, type Root, type RootOptions } from "react-dom/client"
+import type { RenderDriver } from "./Driver.js"
+
+export interface DomRoot {
+  readonly container: Element
+  readonly root: Root
+}
+
+export interface DomOptions {
+  readonly container: Element
+}
+
+export interface DomDriverConfig {
+  readonly rootOptions?: RootOptions
+}
+
+export type DomDriver = RenderDriver<DomOptions, DomRoot>
+
+export const driver = (config?: DomDriverConfig): DomDriver => ({
+  make: (options) =>
+    Effect.acquireRelease(
+      Effect.sync(() => ({
+        container: options.container,
+        root: createRoot(options.container, config?.rootOptions)
+      } satisfies DomRoot)),
+      ({ root }) =>
+        Effect.sync(() => {
+          root.unmount()
+        })
+    ),
+  render: (domRoot, element) =>
+    Effect.sync(() => {
+      flushSync(() => {
+        domRoot.root.render(element)
+      })
+    })
+})

--- a/packages-native/render/src/index.ts
+++ b/packages-native/render/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./Driver.js"
+export * from "./Render.js"
+export * from "./dom.js"

--- a/packages-native/render/test/DomDriver.test.tsx
+++ b/packages-native/render/test/DomDriver.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "@effect/vitest"
+import * as Deferred from "effect/Deferred"
+import * as Effect from "effect/Effect"
+import * as Ref from "effect/Ref"
+import * as React from "react"
+import { RenderTag, layer } from "@effect-native/render"
+import { driver } from "@effect-native/render/dom"
+
+describe("DOM driver", () => {
+  const domLayer = layer(driver())
+
+  it.effect("renders into the provided container", () =>
+    Effect.scoped(
+      Effect.gen(function*() {
+        const service = yield* RenderTag
+        const container = document.createElement("div")
+        const root = yield* service.withRoot({ container })
+
+        yield* service.render(root, <span>first</span>)
+        expect(container.textContent).toBe("first")
+
+        yield* service.render(root, <span>second</span>)
+        expect(container.textContent).toBe("second")
+      })
+    ).pipe(Effect.provide(domLayer)))
+
+  it.effect("unmounts the React tree when the scope ends", () =>
+    Effect.gen(function*() {
+      const container = document.createElement("div")
+
+      yield* Effect.scoped(
+        Effect.gen(function*() {
+          const service = yield* RenderTag
+          const root = yield* service.withRoot({ container })
+          yield* service.render(root, <span>value</span>)
+          expect(container.textContent).toBe("value")
+        })
+      ).pipe(Effect.provide(domLayer))
+
+      expect(container.textContent).toBe("")
+    }))
+
+  it.effect("bridges DOM events through Effect handlers", () =>
+    Effect.scoped(
+      Effect.gen(function*() {
+        const service = yield* RenderTag
+        const container = document.createElement("div")
+        const root = yield* service.withRoot({ container })
+        const count = yield* Ref.make(0)
+        const done = yield* Deferred.make<void>()
+
+        const onClick = service.event(() =>
+          Effect.gen(function*() {
+            yield* Ref.update(count, (n) => n + 1)
+            yield* Deferred.succeed(done, undefined)
+          })
+        )
+
+        yield* service.render(root, <button onClick={onClick}>Click</button>)
+
+        const button = container.querySelector("button")
+        expect(button).not.toBeNull()
+
+        yield* Effect.sync(() => {
+          React.act(() => {
+            button!.click()
+          })
+        })
+
+        yield* Deferred.await(done)
+        const value = yield* Ref.get(count)
+        expect(value).toBe(1)
+      })
+    ).pipe(Effect.provide(domLayer)))
+})

--- a/packages-native/render/test/RenderService.test.tsx
+++ b/packages-native/render/test/RenderService.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as React from "react"
+import type { RenderDriver } from "@effect-native/render"
+import { RenderTag, layer } from "@effect-native/render"
+
+describe("Render service", () => {
+  interface TestOptions {
+    readonly id: string
+  }
+
+  interface TestRoot {
+    readonly options: TestOptions
+    readonly renders: Array<React.ReactElement>
+    disposed: boolean
+  }
+
+  const makeTestDriver = (): RenderDriver<TestOptions, TestRoot> => ({
+    make: (options) =>
+      Effect.acquireRelease(
+        Effect.sync(() => ({
+          options,
+          renders: [],
+          disposed: false
+        } satisfies TestRoot)),
+        (root) => Effect.sync(() => {
+          root.disposed = true
+        })
+      ),
+    render: (root, element) =>
+      Effect.sync(() => {
+        root.renders.push(element as React.ReactElement)
+      })
+  })
+
+  const renderLayer = layer(makeTestDriver())
+
+  it.effect("renders sequential updates without remount", () =>
+    Effect.scoped(
+      Effect.gen(function*() {
+        const service = yield* RenderTag
+        const root = yield* service.withRoot({ id: "app" })
+
+        yield* service.render(root, <span>first</span>)
+        yield* service.render(root, <span>second</span>)
+
+        expect(root.renders).toHaveLength(2)
+        expect(root.renders[0].props.children).toBe("first")
+        expect(root.renders[1].props.children).toBe("second")
+        expect(root.disposed).toBe(false)
+      })
+    ).pipe(Effect.provide(renderLayer)))
+
+  it.effect("disposes roots when scope exits", () =>
+    Effect.gen(function*() {
+      const result = yield* Effect.scoped(
+        Effect.gen(function*() {
+          const service = yield* RenderTag
+          const root = yield* service.withRoot({ id: "scoped" })
+          yield* service.render(root, <div />)
+          return root
+        })
+      ).pipe(Effect.provide(renderLayer))
+
+      expect(result.disposed).toBe(true)
+    }))
+})

--- a/packages-native/render/tsconfig.build.json
+++ b/packages-native/render/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  "compilerOptions": {
+    "outDir": "build/esm",
+    "declarationDir": "build/dts",
+    "jsx": "react-jsx"
+  },
+  "references": []
+}

--- a/packages-native/render/tsconfig.json
+++ b/packages-native/render/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["types/**/*.d.ts"],
+  "references": [
+    { "path": "tsconfig.src.json" },
+    { "path": "tsconfig.test.json" }
+  ],
+  "exclude": ["dist/**/*"]
+}

--- a/packages-native/render/tsconfig.src.json
+++ b/packages-native/render/tsconfig.src.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "references": [],
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "rootDir": "src",
+    "outDir": "build/esm",
+    "jsx": "react-jsx"
+  }
+}

--- a/packages-native/render/tsconfig.test.json
+++ b/packages-native/render/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["test"],
+  "references": [
+    { "path": "tsconfig.src.json" }
+  ],
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
+    "rootDir": "test",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["node", "vitest"],
+    "paths": {
+      "@effect-native/render": ["./src/index.ts"],
+      "@effect-native/render/*": ["./src/*.ts"]
+    }
+  }
+}

--- a/packages-native/render/vitest.config.ts
+++ b/packages-native/render/vitest.config.ts
@@ -1,0 +1,12 @@
+import { mergeConfig, type ViteUserConfig } from "vitest/config"
+import shared from "../../vitest.shared.js"
+
+const config: ViteUserConfig = {
+  test: {
+    environment: "jsdom",
+    include: ["test/**/*.test.ts", "test/**/*.test.tsx"],
+    watch: false
+  }
+}
+
+export default mergeConfig(shared, config)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,7 +157,7 @@ importers:
         version: 6.3.5(@types/node@22.16.4)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.16.4)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.16.4)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(jsdom@24.1.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
   packages-native/bun-test:
     devDependencies:
@@ -226,6 +226,28 @@ importers:
       effect:
         specifier: ^3.17.11
         version: 3.17.11
+    publishDirectory: dist
+
+  packages-native/render:
+    devDependencies:
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.24
+      '@types/react-dom':
+        specifier: ^18.3.5
+        version: 18.3.7(@types/react@18.3.24)
+      effect:
+        specifier: ^3.17.11
+        version: 3.17.11
+      jsdom:
+        specifier: ^24.1.3
+        version: 24.1.3
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
     publishDirectory: dist
 
   scratchpad:
@@ -365,6 +387,9 @@ packages:
 
   '@anthropic-ai/tokenizer@0.0.4':
     resolution: {integrity: sha512-EHRKbxlxlc8W4KCBEseByJ7YwyYCmgu9OyN59H9+IYIGPoKv8tXyQXinkeGDI+cI8Tiuz9wk2jZb/kK7AyvL7g==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -795,6 +820,34 @@ packages:
 
   '@cloudflare/workers-types@4.20250715.0':
     resolution: {integrity: sha512-uMp+ClvvhNlk3ojIgWuIB5Zteq4YVmZcyX16hpJ8eCeCX3izagfEZwXe/vETlv4cc5vtM3xAOMdV//0BD0E98g==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dependents/detective-less@4.1.0':
     resolution: {integrity: sha512-KrkT6qO5NxqNfy68sBl6CTSoJ4SNDIS5iQArkibhlbGU4LaDukZ3q2HIkh8aUKDio6o4itU4xDR7t82Y2eP1Bg==}
@@ -2123,6 +2176,17 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.24':
+    resolution: {integrity: sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==}
+
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
 
@@ -2522,6 +2586,9 @@ packages:
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   autolinker@0.28.1:
     resolution: {integrity: sha512-zQAFO1Dlsn69eXaO6+7YZc+v84aquQKbwpzCE3L0stj56ERn9hutFxPopViLjo9G+rWwjozRhgS5KJ25Xy19cQ==}
 
@@ -2640,7 +2707,6 @@ packages:
 
   bun@1.2.21:
     resolution: {integrity: sha512-y0lJ02dS90U3PJm+7KAKY8Se95AQvP5Xm77LouUwrpNOHpv59kBG4SK1+9iE1cAhpUaFipq+0EJ56S6MmE3row==}
-    cpu: [arm64, x64, aarch64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -2775,6 +2841,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
@@ -2836,12 +2906,20 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -2882,6 +2960,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -2928,6 +3009,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
@@ -3531,6 +3616,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -3727,6 +3816,10 @@ packages:
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -3975,6 +4068,9 @@ packages:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
@@ -4169,6 +4265,15 @@ packages:
       '@babel/preset-env':
         optional: true
 
+  jsdom@24.1.3:
+    resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
@@ -4256,7 +4361,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lighthouse-logger@1.4.2:
@@ -4682,6 +4786,9 @@ packages:
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
 
+  nwsapi@2.2.22:
+    resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
+
   ob1@0.82.5:
     resolution: {integrity: sha512-QyQQ6e66f+Ut/qUVjEce0E/wux5nAGLXYZDn1jr15JWstHsCH3l6VVrg8NKDptW9NEiBXKOJeGF/ydxeSDF3IQ==}
     engines: {node: '>=18.18'}
@@ -4982,6 +5089,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -4994,6 +5104,9 @@ packages:
 
   quansync@0.2.10:
     resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5019,6 +5132,11 @@ packages:
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -5038,6 +5156,10 @@ packages:
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
   react@19.1.0:
@@ -5132,6 +5254,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
   resolve-dependency-path@3.0.2:
     resolution: {integrity: sha512-Tz7zfjhLfsvR39ADOSk9us4421J/1ztVBo4rWUkF38hgHK5m0OCZ3NxFVpqHRkjctnwVa15igEUHFJp8MCS7vA==}
     engines: {node: '>=14'}
@@ -5179,6 +5304,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-applescript@7.0.0:
     resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
     engines: {node: '>=18'}
@@ -5218,6 +5349,13 @@ packages:
     resolution: {integrity: sha512-t0X5PaizPc2H4+rCwszAqHZRtr4bugo4pgiCvrBFvIX0XFxnr29g77LJcpyj9A0DcKf7gXMLcgvRjsonYI6x4g==}
     engines: {node: '>=14'}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -5489,6 +5627,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tapable@2.2.2:
     resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
     engines: {node: '>=6'}
@@ -5588,8 +5729,16 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -5710,6 +5859,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -5725,6 +5878,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -5820,6 +5976,10 @@ packages:
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walkdir@0.4.1:
     resolution: {integrity: sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==}
     engines: {node: '>=6.0.0'}
@@ -5862,6 +6022,10 @@ packages:
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
@@ -5955,6 +6119,13 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -5994,6 +6165,14 @@ snapshots:
     dependencies:
       '@types/node': 18.19.119
       tiktoken: 1.0.21
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -6668,6 +6847,26 @@ snapshots:
 
   '@cloudflare/workers-types@4.20250715.0': {}
 
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
   '@dependents/detective-less@4.1.0':
     dependencies:
       gonzales-pe: 4.3.0
@@ -7013,7 +7212,7 @@ snapshots:
   '@effect/vitest@0.25.1(effect@3.17.11)(vitest@3.2.4)':
     dependencies:
       effect: 3.17.11
-      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@24.0.14)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@24.0.14)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(jsdom@24.1.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
   '@effect/wa-sqlite@0.1.2': {}
 
@@ -7914,6 +8113,17 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.24)':
+    dependencies:
+      '@types/react': 18.3.24
+
+  '@types/react@18.3.24':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.1.3
+
   '@types/react@19.1.8':
     dependencies:
       csstype: 3.1.3
@@ -8126,7 +8336,7 @@ snapshots:
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.16.4)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.16.4)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(jsdom@24.1.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.54.1
@@ -8145,7 +8355,7 @@ snapshots:
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@24.0.14)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@24.0.14)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(jsdom@24.1.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.54.1
@@ -8171,7 +8381,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.16.4)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.16.4)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(jsdom@24.1.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
     optionalDependencies:
       '@vitest/browser': 3.2.4(playwright@1.54.1)(vite@6.3.5(@types/node@22.16.4)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
     transitivePeerDependencies:
@@ -8230,7 +8440,7 @@ snapshots:
   '@vitest/web-worker@3.2.4(vitest@3.2.4)':
     dependencies:
       debug: 4.4.1
-      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.16.4)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.16.4)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(jsdom@24.1.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8387,6 +8597,8 @@ snapshots:
   async-function@1.0.0: {}
 
   async-limiter@1.0.1: {}
+
+  asynckit@0.4.0: {}
 
   autolinker@0.28.1:
     dependencies:
@@ -8715,6 +8927,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@10.0.1: {}
 
   commander@12.1.0: {}
@@ -8778,9 +8994,19 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.1.3: {}
 
   data-uri-to-buffer@4.0.1: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -8813,6 +9039,8 @@ snapshots:
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -8850,6 +9078,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   denque@2.1.0: {}
 
@@ -9539,6 +9769,14 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
@@ -9752,6 +9990,10 @@ snapshots:
       hermes-estree: 0.29.1
 
   hosted-git-info@2.8.9: {}
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
 
@@ -9995,6 +10237,8 @@ snapshots:
   is-plain-object@2.0.4:
     dependencies:
       isobject: 3.0.1
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-property@1.0.2: {}
 
@@ -10241,6 +10485,34 @@ snapshots:
       write-file-atomic: 5.0.1
     transitivePeerDependencies:
       - supports-color
+
+  jsdom@24.1.3:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.4
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.22
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@2.5.2: {}
 
@@ -10863,6 +11135,8 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
+  nwsapi@2.2.22: {}
+
   ob1@0.82.5:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -11184,6 +11458,10 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -11194,6 +11472,8 @@ snapshots:
   pure-rand@6.1.0: {}
 
   quansync@0.2.10: {}
+
+  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -11225,6 +11505,12 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
 
   react-is@17.0.2: {}
 
@@ -11278,6 +11564,10 @@ snapshots:
       - utf-8-validate
 
   react-refresh@0.14.2: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   react@19.1.0: {}
 
@@ -11394,6 +11684,8 @@ snapshots:
 
   requirejs@2.3.7: {}
 
+  requires-port@1.0.0: {}
+
   resolve-dependency-path@3.0.2: {}
 
   resolve-from@3.0.0: {}
@@ -11452,6 +11744,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.45.1
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   run-applescript@7.0.0: {}
 
   run-parallel@1.2.0:
@@ -11492,6 +11788,14 @@ snapshots:
   sass-lookup@5.0.1:
     dependencies:
       commander: 10.0.1
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scheduler@0.26.0: {}
 
@@ -11779,6 +12083,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tapable@2.2.2: {}
 
   tar-fs@2.1.3:
@@ -11882,7 +12188,18 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
@@ -12010,6 +12327,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  universalify@0.2.0: {}
+
   unpipe@1.0.0: {}
 
   unrs-resolver@1.11.1:
@@ -12045,6 +12364,11 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   util-deprecate@1.0.2: {}
 
@@ -12131,7 +12455,7 @@ snapshots:
       tsx: 4.20.3
       yaml: 2.8.0
 
-  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.16.4)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0):
+  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.16.4)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(jsdom@24.1.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -12161,6 +12485,7 @@ snapshots:
       '@types/node': 22.16.4
       '@vitest/browser': 3.2.4(playwright@1.54.1)(vite@6.3.5(@types/node@22.16.4)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       happy-dom: 17.6.3
+      jsdom: 24.1.3
     transitivePeerDependencies:
       - jiti
       - less
@@ -12175,7 +12500,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/node@24.0.14)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0):
+  vitest@3.2.4(@edge-runtime/vm@5.0.0)(@types/node@24.0.14)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(jsdom@24.1.3)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -12205,6 +12530,7 @@ snapshots:
       '@types/node': 24.0.14
       '@vitest/browser': 3.2.4(playwright@1.54.1)(vite@6.3.5(@types/node@24.0.14)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       happy-dom: 17.6.3
+      jsdom: 24.1.3
     transitivePeerDependencies:
       - jiti
       - less
@@ -12220,6 +12546,10 @@ snapshots:
       - yaml
 
   vlq@1.0.1: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   walkdir@0.4.1: {}
 
@@ -12240,8 +12570,7 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webidl-conversions@7.0.0:
-    optional: true
+  webidl-conversions@7.0.0: {}
 
   whatwg-encoding@3.1.1:
     dependencies:
@@ -12253,6 +12582,11 @@ snapshots:
     optional: true
 
   whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -12346,6 +12680,10 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.base.json",
   "include": [],
   "references": [
-    { "path": "packages-native/bun-test" }
+    { "path": "packages-native/bun-test" },
+    { "path": "packages-native/render" }
   ]
 }


### PR DESCRIPTION
## Summary
- add the new `@effect-native/render` package with a generic driver interface and scoped service layer helpers
- implement a React DOM driver that creates and tears down roots via `createRoot` and `flushSync`
- cover the render service and DOM driver with Effect-based Vitest suites

## Testing
- nix develop --command pnpm --filter @effect-native/render test

------
https://chatgpt.com/codex/tasks/task_e_68ca5ccee608832f9d76ec7f16e92e1d