### PR TITLE
fix: relax bidi runtime typing for direct pnpm

### DIFF
--- a/.specs/bidi/progress.md
+++ b/.specs/bidi/progress.md
@@ -1,0 +1,39 @@
+# WebDriver BiDi Implementation Progress
+
+## Milestone 0: Bootstrapping
+- [ ] Provide a runnable WebDriver BiDi transport
+- [x] Implement command routing for request/response pairs
+- [x] Surface WebDriver BiDi events to subscribers
+- [ ] Publish a default JSON transport over WebSocket
+
+## Milestone 1: Platform Transport Layers
+- [ ] Deliver concrete `Layer`s for Firefox, Chrome, Node.js, Bun, and React Native transports
+  - [ ] Document transport capabilities and constraints for each target in `.specs/bidi/research/<target>.md`
+  - [ ] Capture protocol handshake requirements and authentication notes in `.specs/bidi/research/handshake.md`
+  - [ ] Prototype connectivity harnesses in `packages-native/bidi/test/platform` once research notes exist
+
+## Milestone 2: Specification Coverage
+- [ ] Track per-module command and event support in `.specs/bidi/coverage.md`
+- [ ] Implement serialization and validation for core command shapes
+- [ ] Model subscription lifecycles and filtering semantics for events
+
+## Milestone 3: Runtime Productization
+- [ ] Provide example applications for Bun, Node.js, and React Native showcasing layered transports
+- [ ] Harden error reporting and retry semantics for production environments
+- [ ] Establish CI coverage across supported runtimes using the new transports
+
+## Research Backlog
+- [ ] Create `.specs/bidi/research/README.md` describing how findings are recorded and cross-referenced
+- [ ] Survey vendor documentation for Firefox Remote Protocol and Chrome DevTools transport compatibility
+- [ ] Investigate React Native WebSocket limitations and record findings in `.specs/bidi/research/react-native.md`
+- [ ] Determine Bun runtime WebSocket APIs and document them in `.specs/bidi/research/bun.md`
+- [ ] Outline Node.js WebSocket implementation strategy in `.specs/bidi/research/node.md`
+
+## Change Management
+- [ ] Establish a process document in `.specs/bidi/change-log.md` for tracking draft spec revisions
+- [ ] For each new WebDriver BiDi draft, diff the Bikeshed source and summarize required work in `.specs/bidi/change-log.md`
+- [ ] Schedule follow-up PRs when the draft spec adds or amends commands, events, or transport rules
+
+## Notes
+- Implementation follows the [WebDriver BiDi draft specification](https://w3c.github.io/webdriver-bidi/).
+- Progress items will be checked as the implementation evolves across PRs.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "ast-types": "^0.14.2",
     "babel-plugin-annotate-pure-calls": "^0.5.0",
     "dependency-cruiser": "^16.10.4",
+    "effect": "latest",
     "eslint": "^9.35.0",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-codegen": "^0.30.0",

--- a/packages-native/bidi/AGENTS.md
+++ b/packages-native/bidi/AGENTS.md
@@ -1,0 +1,13 @@
+# @effect-native/bidi Contribution Guide
+
+## Documentation
+- JSDoc for every exported symbol must link to the relevant section of the [WebDriver BiDi draft specification](https://w3c.github.io/webdriver-bidi/) using a deep link (e.g. `#commands`, `#events`, `#transport`).
+- When adding new exports, cite the spec anchor with `@see` so docgen consumers can trace the provenance quickly.
+
+## Specs Folder Hygiene
+- Keep `.specs/bidi` synchronized with implementation progress; create or update research notes as soon as experiments are run.
+- Reference research documents from code comments when behavior is grounded in experimentation.
+
+## Testing & Tooling
+- Run `nix develop --command pnpm --filter @effect-native/bidi test` for package-level changes.
+- Run `nix develop --command pnpm lint --fix` after touching TypeScript sources.

--- a/packages-native/bidi/CHANGELOG.md
+++ b/packages-native/bidi/CHANGELOG.md
@@ -1,0 +1,6 @@
+# @effect-native/bidi
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+- Initial scaffold.

--- a/packages-native/bidi/LICENSE
+++ b/packages-native/bidi/LICENSE
@@ -1,0 +1,1 @@
+See the root LICENSE file.

--- a/packages-native/bidi/README.md
+++ b/packages-native/bidi/README.md
@@ -1,0 +1,34 @@
+# @effect-native/bidi
+
+Opinionated WebDriver BiDi runtime primitives for Effect.
+
+> ⚠️ Work in progress. This package currently exposes the absolute minimum to bootstrap a request/response loop over an abstract transport.
+
+## Usage
+
+```ts
+import * as BiDi from "@effect-native/bidi/BiDi"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Queue from "effect/Queue"
+
+const InMemoryTransportLive = Layer.scoped(
+  BiDi.Transport,
+  Effect.gen(function* () {
+    const outgoing = yield* Queue.unbounded<BiDi.OutgoingMessage>()
+    const incoming = yield* Queue.unbounded<BiDi.IncomingMessage>()
+
+    return {
+      send: (message: BiDi.OutgoingMessage) => Queue.offer(outgoing, message),
+      receive: Queue.take(incoming)
+    }
+  })
+)
+
+const BiDiDemoLive = Layer.mergeAll(
+  InMemoryTransportLive,
+  BiDi.layer
+)
+
+// BunRuntime.runMain(Layer.launch(BiDiDemoLive))
+```

--- a/packages-native/bidi/package.json
+++ b/packages-native/bidi/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@effect-native/bidi",
+  "version": "0.0.0",
+  "type": "module",
+  "license": "MIT",
+  "description": "Opinionated WebDriver BiDi runtime primitives for Effect.",
+  "homepage": "https://github.com/effect-native/effect-native",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/effect-native/effect-native.git",
+    "directory": "packages-native/bidi"
+  },
+  "bugs": {
+    "url": "https://github.com/effect-native/effect-native/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "directory": "dist",
+    "linkDirectory": false,
+    "tag": "latest"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./BiDi": "./src/BiDi.ts",
+    "./internal/*": null
+  },
+  "scripts": {
+    "codegen": "echo '@effect-native/bidi: skip codegen'",
+    "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3",
+    "build-esm": "tsc -b tsconfig.build.json",
+    "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
+    "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest --coverage",
+    "prepublishOnly": "pnpm build"
+  },
+  "peerDependencies": {
+    "effect": "*"
+  },
+  "peerDependenciesMeta": {
+    "effect": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "effect": "latest"
+  },
+  "files": [
+    "build",
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
+}

--- a/packages-native/bidi/src/BiDi.ts
+++ b/packages-native/bidi/src/BiDi.ts
@@ -1,0 +1,144 @@
+/**
+ * WebDriver BiDi runtime primitives that wrap the transport and routing rules.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#transport | WebDriver BiDi § Transport}
+ * @since 0.0.0
+ */
+import * as internal from "./internal/BiDi.js"
+
+/**
+ * A WebDriver BiDi command envelope.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#commands | WebDriver BiDi § Commands}
+ * @since 0.0.0
+ */
+export type Command<Params = unknown> = internal.Command<Params>
+
+/**
+ * The success response for a WebDriver BiDi command.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#commands | WebDriver BiDi § Commands}
+ * @since 0.0.0
+ */
+export type CommandResponse<Result = unknown> = internal.CommandResponse<Result>
+
+/**
+ * The error response payload for a WebDriver BiDi command.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#errors | WebDriver BiDi § Errors}
+ * @since 0.0.0
+ */
+export type CommandError = internal.CommandError
+
+/**
+ * A WebDriver BiDi event notification emitted by the remote end.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#events | WebDriver BiDi § Events}
+ * @since 0.0.0
+ */
+export type Event<Params = unknown> = internal.Event<Params>
+
+/**
+ * Effectful handler invoked when a subscribed WebDriver BiDi event arrives.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#events | WebDriver BiDi § Events}
+ * @since 0.0.0
+ */
+export type EventHandler = internal.EventHandler
+
+/**
+ * Any inbound WebDriver BiDi message from the transport.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#transport | WebDriver BiDi § Transport}
+ * @since 0.0.0
+ */
+export type IncomingMessage = internal.IncomingMessage
+
+/**
+ * Any outbound WebDriver BiDi message sent over the transport.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#transport | WebDriver BiDi § Transport}
+ * @since 0.0.0
+ */
+export type OutgoingMessage = internal.OutgoingMessage
+
+/**
+ * Service contract that sends commands and wires event subscriptions per the specification.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#commands | WebDriver BiDi § Commands}
+ * @see {@link https://w3c.github.io/webdriver-bidi/#events | WebDriver BiDi § Events}
+ * @since 0.0.0
+ */
+export interface BiDiService extends internal.BiDiService {}
+
+/**
+ * Context tag for the WebDriver BiDi service.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#commands | WebDriver BiDi § Commands}
+ * @since 0.0.0
+ */
+export const BiDi = internal.BiDi
+
+/**
+ * Layer constructor that provides the WebDriver BiDi service scoped to a transport.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#transport | WebDriver BiDi § Transport}
+ * @since 0.0.0
+ */
+export const layer = internal.layer
+
+/**
+ * Creates a WebDriver BiDi service instance that manages request correlation and event dispatch.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#transport | WebDriver BiDi § Transport}
+ * @since 0.0.0
+ */
+export const make = internal.make
+
+/**
+ * Transport contract used by the WebDriver BiDi runtime.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#transport | WebDriver BiDi § Transport}
+ * @since 0.0.0
+ */
+export interface Transport extends internal.Transport {}
+
+/**
+ * Context tag for the active WebDriver BiDi transport.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#transport | WebDriver BiDi § Transport}
+ * @since 0.0.0
+ */
+export const Transport = internal.Transport
+
+/**
+ * Failure raised when the transport cannot send a message.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#transport | WebDriver BiDi § Transport}
+ * @since 0.0.0
+ */
+export class TransportSendError extends internal.TransportSendError {}
+
+/**
+ * Failure raised when receiving from the transport fails.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#transport | WebDriver BiDi § Transport}
+ * @since 0.0.0
+ */
+export class TransportReceiveError extends internal.TransportReceiveError {}
+
+/**
+ * Failure raised when the transport closes and pending commands are cancelled.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#transport | WebDriver BiDi § Transport}
+ * @since 0.0.0
+ */
+export class TransportClosed extends internal.TransportClosed {}
+
+/**
+ * Failure raised when the remote end reports a command error.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#errors | WebDriver BiDi § Errors}
+ * @since 0.0.0
+ */
+export class CommandFailed extends internal.CommandFailed {}

--- a/packages-native/bidi/src/index.ts
+++ b/packages-native/bidi/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Entry point for the WebDriver BiDi public API surface.
+ *
+ * @see {@link https://w3c.github.io/webdriver-bidi/#introduction | WebDriver BiDi § Introduction}
+ * @since 0.0.0
+ */
+export * as BiDi from "./BiDi.js"

--- a/packages-native/bidi/src/internal/BiDi.ts
+++ b/packages-native/bidi/src/internal/BiDi.ts
@@ -1,0 +1,254 @@
+/**
+ * Internal WebDriver BiDi runtime helpers.
+ *
+ * @since 0.0.0
+ * @internal
+ */
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+import * as Deferred from "effect/Deferred"
+import * as Effect from "effect/Effect"
+import * as Fiber from "effect/Fiber"
+import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
+import * as Ref from "effect/Ref"
+import type * as Scope from "effect/Scope"
+
+/** @internal */
+export interface Command<Params = unknown> {
+  readonly method: string
+  readonly params?: Params
+}
+
+/** @internal */
+export interface CommandResponse<Result = unknown> {
+  readonly id: number
+  readonly result: Result
+}
+
+/** @internal */
+export interface CommandError {
+  readonly id: number
+  readonly error: {
+    readonly error: string
+    readonly message: string
+    readonly stacktrace?: string
+  }
+}
+
+/** @internal */
+export interface Event<Params = unknown> {
+  readonly method: string
+  readonly params: Params
+}
+
+/** @internal */
+export type IncomingMessage = CommandResponse | CommandError | Event
+
+/** @internal */
+export type OutgoingMessage<Params = unknown> = {
+  readonly id: number
+  readonly method: string
+  readonly params?: Params
+}
+
+/** @internal */
+export class TransportSendError extends Data.TaggedError("TransportSendError")<{
+  readonly cause: unknown
+}> {}
+
+/** @internal */
+export class TransportReceiveError extends Data.TaggedError("TransportReceiveError")<{
+  readonly cause: unknown
+}> {}
+
+/** @internal */
+export class TransportClosed extends Data.TaggedError("TransportClosed")<{
+  readonly cause: TransportReceiveError
+}> {}
+
+/** @internal */
+export class CommandFailed extends Data.TaggedError("CommandFailed")<{
+  readonly id: number
+  readonly method: string
+  readonly error: CommandError["error"]
+}> {}
+
+/** @internal */
+export interface Transport {
+  readonly send: <Params>(message: OutgoingMessage<Params>) => Effect.Effect<void, TransportSendError>
+  readonly receive: Effect.Effect<IncomingMessage, TransportReceiveError>
+}
+
+/** @internal */
+export type EventHandler = (event: Event) => Effect.Effect<void>
+
+/** @internal */
+export interface BiDiService {
+  readonly send: <Params>(
+    command: Command<Params>
+  ) => Effect.Effect<unknown, CommandFailed | TransportSendError | TransportClosed>
+  readonly onEvent: (method: string, handler: EventHandler) => Effect.Effect<void, never, Scope.Scope>
+}
+
+/** @internal */
+export const Transport = Context.GenericTag<Transport>("@effect-native/bidi/Transport")
+
+/** @internal */
+export const BiDi = Context.GenericTag<BiDiService>("@effect-native/bidi/BiDi")
+
+interface PendingEntry {
+  readonly method: string
+  readonly deferred: Deferred.Deferred<unknown, CommandFailed | TransportClosed>
+}
+
+const isCommandResponse = (message: IncomingMessage): message is CommandResponse =>
+  Object.prototype.hasOwnProperty.call(message, "id") &&
+  Object.prototype.hasOwnProperty.call(message, "result")
+
+const isCommandError = (message: IncomingMessage): message is CommandError =>
+  Object.prototype.hasOwnProperty.call(message, "id") &&
+  Object.prototype.hasOwnProperty.call(message, "error")
+
+const toOutgoing = <Params>(id: number, command: Command<Params>): OutgoingMessage<Params> =>
+  command.params === undefined
+    ? { id, method: command.method }
+    : { id, method: command.method, params: command.params }
+
+/** @internal */
+export const make = Effect.gen(function*(_) {
+  const transport = yield* Transport
+  const counter = yield* Ref.make(0)
+  const pending = yield* Ref.make(new Map<number, PendingEntry>())
+  const listeners = yield* Ref.make(new Map<string, ReadonlyArray<EventHandler>>())
+  const closed = yield* Ref.make<Option.Option<TransportClosed>>(Option.none())
+
+  const takePending = (id: number) =>
+    Ref.modify(pending, (map) => {
+      const next = new Map(map)
+      const entry = next.get(id)
+      if (entry !== undefined) {
+        next.delete(id)
+        return [Option.some(entry), next] as const
+      }
+      return [Option.none<PendingEntry>(), map] as const
+    })
+
+  const markClosed = (error: TransportReceiveError) =>
+    Effect.gen(function*() {
+      const current = yield* Ref.get(closed)
+      if (Option.isSome(current)) {
+        return current.value
+      }
+      const closure = new TransportClosed({ cause: error })
+      yield* Ref.set(closed, Option.some(closure))
+      const snapshot = yield* Ref.getAndSet(pending, new Map())
+      yield* Effect.forEach(snapshot.values(), (entry) => Deferred.fail(entry.deferred, closure), {
+        discard: true
+      })
+      return closure
+    })
+
+  const dispatchEvent = (event: Event) =>
+    Effect.gen(function*() {
+      const registry = yield* Ref.get(listeners)
+      const handlers = registry.get(event.method)
+      if (!handlers || handlers.length === 0) {
+        return
+      }
+      yield* Effect.forEach(handlers, (handler) => handler(event), { discard: true })
+    })
+
+  const processMessage = (message: IncomingMessage) =>
+    Effect.gen(function*() {
+      if (isCommandResponse(message)) {
+        const entry = yield* takePending(message.id)
+        if (Option.isSome(entry)) {
+          yield* Deferred.succeed(entry.value.deferred, message.result)
+        }
+        return
+      }
+      if (isCommandError(message)) {
+        const entry = yield* takePending(message.id)
+        if (Option.isSome(entry)) {
+          yield* Deferred.fail(
+            entry.value.deferred,
+            new CommandFailed({ id: message.id, method: entry.value.method, error: message.error })
+          )
+        }
+        return
+      }
+      yield* dispatchEvent(message)
+    })
+
+  const loop = Effect.forever(
+    transport.receive.pipe(
+      Effect.flatMap(processMessage),
+      Effect.catchAll((error) => markClosed(error).pipe(Effect.flatMap((closure) => Effect.fail(closure))))
+    )
+  )
+
+  const fiber = yield* Effect.forkDaemon(loop)
+  yield* Effect.addFinalizer(() => Fiber.interrupt(fiber))
+
+  const send = <Params>(command: Command<Params>) =>
+    Effect.gen(function*() {
+      const status = yield* Ref.get(closed)
+      if (Option.isSome(status)) {
+        return yield* Effect.fail(status.value)
+      }
+      const id = yield* Ref.updateAndGet(counter, (n) => n + 1)
+      const deferred = yield* Deferred.make<unknown, CommandFailed | TransportClosed>()
+      yield* Ref.update(pending, (map) => {
+        const next = new Map(map)
+        next.set(id, { method: command.method, deferred })
+        return next
+      })
+      const request = toOutgoing(id, command)
+      return yield* Effect.matchEffect(transport.send(request), {
+        onFailure: (error) =>
+          Effect.gen(function*() {
+            yield* Ref.update(pending, (map) => {
+              const next = new Map(map)
+              next.delete(id)
+              return next
+            })
+            return yield* Effect.fail(error)
+          }),
+        onSuccess: () => Deferred.await(deferred)
+      })
+    })
+
+  const onEvent = (method: string, handler: EventHandler) =>
+    Effect.acquireRelease(
+      Ref.update(listeners, (map) => {
+        const next = new Map(map)
+        const existing = next.get(method) ?? []
+        next.set(method, [...existing, handler])
+        return next
+      }),
+      () =>
+        Ref.update(listeners, (map) => {
+          const next = new Map(map)
+          const existing = next.get(method)
+          if (!existing) {
+            return next
+          }
+          const filtered = existing.filter((candidate) => candidate !== handler)
+          if (filtered.length === 0) {
+            next.delete(method)
+          } else {
+            next.set(method, filtered)
+          }
+          return next
+        })
+    )
+
+  return {
+    send,
+    onEvent
+  }
+})
+
+/** @internal */
+export const layer = Layer.scoped(BiDi, make)

--- a/packages-native/bidi/test/BiDi.test.ts
+++ b/packages-native/bidi/test/BiDi.test.ts
@@ -1,0 +1,79 @@
+import * as BiDi from "@effect-native/bidi/BiDi"
+import { describe, expect, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Fiber from "effect/Fiber"
+import * as Queue from "effect/Queue"
+
+describe("BiDi", () => {
+  it.effect("correlates command responses", () =>
+    Effect.scoped(
+      Effect.gen(function*(_) {
+        const outgoing = yield* Queue.unbounded<BiDi.OutgoingMessage>()
+        const incoming = yield* Queue.unbounded<BiDi.IncomingMessage>()
+
+        const transport: BiDi.Transport = {
+          send: (message) => Queue.offer(outgoing, message),
+          receive: Queue.take(incoming)
+        }
+
+        const bidi = yield* BiDi.make.pipe(
+          Effect.provideService(BiDi.Transport, transport)
+        )
+
+        const fiber = yield* Effect.fork(
+          bidi.send({ method: "session.new", params: { capabilities: {} } })
+        )
+
+        const message = yield* Queue.take(outgoing)
+        expect(message).toMatchObject({
+          method: "session.new",
+          params: { capabilities: {} }
+        })
+
+        yield* Queue.offer(incoming, {
+          id: message.id,
+          result: { sessionId: "test" }
+        })
+
+        const result = yield* Fiber.join(fiber)
+        expect(result).toEqual({ sessionId: "test" })
+      })
+    ))
+
+  it.effect("fails with CommandFailed when session.new rejects", () =>
+    Effect.scoped(
+      Effect.gen(function*(_) {
+        const outgoing = yield* Queue.unbounded<BiDi.OutgoingMessage>()
+        const incoming = yield* Queue.unbounded<BiDi.IncomingMessage>()
+
+        const transport: BiDi.Transport = {
+          send: (message) => Queue.offer(outgoing, message),
+          receive: Queue.take(incoming)
+        }
+
+        const bidi = yield* BiDi.make.pipe(
+          Effect.provideService(BiDi.Transport, transport)
+        )
+
+        const fiber = yield* Effect.fork(
+          bidi.send({ method: "session.new", params: { capabilities: {} } })
+        )
+
+        const message = yield* Queue.take(outgoing)
+        yield* Queue.offer(incoming, {
+          id: message.id,
+          error: {
+            error: "session.error",
+            message: "not allowed"
+          }
+        })
+
+        const failure = yield* Fiber.join(fiber).pipe(Effect.flip)
+        if ((failure as { readonly _tag?: string })._tag !== "CommandFailed") {
+          throw new Error(`unexpected failure: ${JSON.stringify(failure)}`)
+        }
+        expect(failure.method).toBe("session.new")
+        expect(failure.error.error).toBe("session.error")
+      })
+    ))
+})

--- a/packages-native/bidi/tsconfig.build.json
+++ b/packages-native/bidi/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.src.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "tsBuildInfoFile": ".tsbuildinfo/build.tsbuildinfo",
+    "outDir": "build/esm",
+    "declarationDir": "build/dts",
+    "stripInternal": true
+  }
+}

--- a/packages-native/bidi/tsconfig.json
+++ b/packages-native/bidi/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [],
+  "references": [
+    { "path": "tsconfig.src.json" },
+    { "path": "tsconfig.test.json" }
+  ]
+}

--- a/packages-native/bidi/tsconfig.src.json
+++ b/packages-native/bidi/tsconfig.src.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "build/src",
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "rootDir": "src"
+  }
+}

--- a/packages-native/bidi/tsconfig.test.json
+++ b/packages-native/bidi/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["test"],
+  "references": [
+    { "path": "tsconfig.src.json" }
+  ],
+  "compilerOptions": {
+    "types": ["node"],
+    "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
+    "rootDir": "test",
+    "outDir": "build/test"
+  }
+}

--- a/packages-native/bidi/vitest.config.ts
+++ b/packages-native/bidi/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from "vitest/config"
+import shared from "../../vitest.shared"
+
+export default defineConfig(shared)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       dependency-cruiser:
         specifier: ^16.10.4
         version: 16.10.4
+      effect:
+        specifier: latest
+        version: 3.17.14
       eslint:
         specifier: ^9.35.0
         version: 9.35.0
@@ -158,6 +161,13 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.18.4)(@vitest/browser@3.2.4)(happy-dom@17.6.3)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.0)
+
+  packages-native/bidi:
+    dependencies:
+      effect:
+        specifier: latest
+        version: 3.17.14
+    publishDirectory: dist
 
   packages-native/bun-test:
     dependencies:
@@ -4308,7 +4318,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lighthouse-logger@1.4.2:


### PR DESCRIPTION
## Summary
- add effect as a workspace dev dependency so BiDi resolves its optional peer outside the nix shell
- simplify the BiDi service typing so command results are tracked as unknown without unsafe assertions
- collapse event handler generics to a single shape for easier registration while keeping spec links intact

## Testing
- pnpm test --run
- pnpm lint-fix
- pnpm check
- pnpm circular
- pnpm codegen
- pnpm test-types --target current
- pnpm docgen
- pnpm codemod
- pnpm build
- node scripts/verify-subpaths.mjs

------
https://chatgpt.com/codex/tasks/task_e_68d6f9e082f8832f82a4ce3673d79f64