### PR TITLE
Add initial @effect/money specification documents

### DIFF
--- a/.specs/money/design.md
+++ b/.specs/money/design.md
@@ -1,0 +1,131 @@
+# @effect/money Specification: Design
+
+## Package Topology
+
+Following the precedent set by `@effect/platform`, the financial packages will be structured as:
+
+- **`@effect/money`** – Core domain schemas, capability descriptors, error types, and abstract services. Purely declarative and dependency-free aside from Effect, Schema, and Data.
+- **`@effect/money-client`** – Shared client utilities (retry/backoff, pagination helpers, contract-test harness) for applications and driver authors.
+- **`@effect/money-storage`** – Optional abstractions for persistence (credential stores, sync checkpoints, audit event sinks) expressed as Effect services without concrete storage dependencies.
+- **`@effect/money-*` driver packages** – Institution, network, or infrastructure-specific implementations (e.g., `@effect/money-plaid`, `@effect/money-treasury-prime`, `@effect/money-ledger-firestore`). Each driver provides Layers satisfying the core services and declares capabilities.
+
+The spec focuses on the first three packages; drivers will be defined in follow-up specs that reference this contract.
+
+## Module Layout (Core Package)
+
+```
+packages/money/
+  src/
+    Schema/
+      Institution.ts
+      Party.ts
+      Account.ts
+      Instrument.ts
+      Transaction.ts
+      Balance.ts
+      Statement.ts
+      Mandate.ts
+      Transfer.ts
+      StandingInstruction.ts
+      ExchangeRate.ts
+      Common.ts (identifiers, enums, money amounts)
+    Capability/
+      descriptors.ts (structured capability taxonomy)
+      matrix.ts (lookup utilities)
+    Errors/
+      index.ts (Data.TaggedError hierarchies)
+    Services/
+      InstitutionDirectory.ts
+      AccountAggregation.ts
+      Transactions.ts
+      Transfers.ts
+      StandingInstructions.ts
+      Balances.ts
+      Statements.ts
+      Compliance.ts
+      Onboarding.ts
+      ExchangeRates.ts
+    Auditing/
+      Events.ts (event payload schemas)
+      Correlation.ts (ID utilities)
+    index.ts (public exports)
+    internal/ (shared helpers not exported publicly)
+```
+
+### Schema Design Principles
+
+1. **Composable Building Blocks**: Define primitives in `Schema/Common.ts` such as `MoneyAmount`, `CurrencyCode`, `AccountId`, `InstitutionId`, `Timestamp`, `Percentage`, and `LocalizedString`. All other schemas reference these primitives to ensure consistency.
+2. **Branded Identifiers**: Use `Schema.Brand` to create strongly typed IDs (e.g., `type AccountId = Schema.Brand<Schema.UUID, "AccountId">`).
+3. **Status Machines**: Model lifecycle states using literal unions (e.g., `TransactionStatus = "pending" | "posted" | "reversed" | ...`). Include transitions in documentation to guide driver behavior.
+4. **Audit Fields**: Every entity includes `source`, `capturedAt`, `receivedAt`, `lastUpdatedAt`, and optional `provenance` objects describing the integration, API version, and credential reference.
+5. **Extension Slots**: Provide `extensions?: Schema.ReadonlyArray<ExtensionEnvelope>` where `ExtensionEnvelope` captures `{ namespace: Schema.NonEmptyString, data: Schema.JsonRecord }`, allowing institution-specific metadata without polluting the core schema.
+6. **Relationship References**: Use typed IDs and optional embedded summaries (e.g., `accountSummary?: AccountSummary`) to support efficient consumption without requiring secondary fetches.
+
+### Service Contracts
+
+Each service module exports:
+
+- **Service Tag** (`const InstitutionDirectoryService = Context.Tag<...>()`).
+- **Interface** describing operations with typed inputs/outputs (using `Effect` and `Stream`).
+- **Layer constructors** for composition (e.g., `InstitutionDirectory.layer`, `InstitutionDirectory.withClient`).
+- **Capability negotiation** functions enabling runtime checks (e.g., `hasCapability("transactions.streaming")`).
+
+Example (pseudocode):
+
+```ts
+export interface InstitutionDirectoryService {
+  readonly list: Effect<ReadonlyArray<Institution>>;
+  readonly get: (id: InstitutionId) => Effect<Option<Institution>>;
+  readonly capabilities: (id: InstitutionId) => Effect<CapabilityMatrix>;
+}
+```
+
+Error types (e.g., `InstitutionError`, `TransactionError`) extend `Data.TaggedError` with discriminants (`_tag`, `reason`, `institutionId`, `retryable`). Services document which errors may surface and under what conditions.
+
+### Capability Taxonomy
+
+The `Capability/descriptors.ts` module defines a hierarchical taxonomy:
+
+- **Domain** (`accounts`, `transactions`, `transfers`, `statements`, `fx`, `compliance`).
+- **Features** (`realTime`, `historical`, `streaming`, `batch`, `sameDay`, `wire`, `ach`, `sepa`, etc.).
+- **Constraints** (limits, cutoff windows, supported currencies, jurisdictions).
+
+Capabilities are modeled as schemas allowing drivers to advertise support, optionally including quantitative limits. Applications query capabilities before invoking services, enabling graceful degradation.
+
+### Auditing & Observability
+
+- **Event schemas** describe standard events (`SyncStarted`, `SyncCompleted`, `TransferInitiated`, `TransferSettled`, `TransferFailed`, `MandateCreated`, `ConsentRevoked`).
+- Services emit events via an optional `AuditEventSink` service defined in `@effect/money-storage`. Drivers depend on the sink but do not assume a specific implementation.
+
+### Storage Abstractions
+
+`@effect/money-storage` defines interfaces for:
+
+- `CredentialStore` – persist encrypted institution credentials and OAuth tokens.
+- `SyncStateStore` – track cursors, last success timestamps, incremental sync state.
+- `TransferStore` – persist transfer instructions and state transitions for idempotency.
+- `AuditEventSink` – append-only store for audit events (e.g., Kafka, Postgres, file-based).
+
+Each interface relies solely on `Effect` primitives and is optionally provided by applications or driver bundles.
+
+### Contract Testing Toolkit
+
+`@effect/money-client` provides:
+
+- Schema validation helpers to assert driver outputs conform to core schemas.
+- Standardized mock servers for verifying webhook handling and OAuth flows.
+- Harness utilities for running cross-driver test suites (e.g., verifying transactions streaming). This mirrors `@effect/platform/test` patterns.
+
+## Extension Strategy
+
+- Drivers extend via the `extensions` field and may expose additional services in their own namespace (e.g., brokerage-specific order management). Core package remains stable.
+- Provide recommended naming for driver packages (`@effect/money-{institution|provider}`) and persistence packages (`@effect/money-storage-{backend}`).
+- Encourage cross-domain bridges (e.g., linking `@effect/platform` HTTP clients for driver communication).
+
+## Open Questions
+
+- Should we include real-time payment network orchestration (RTP, FedNow) in the initial capability taxonomy or treat it as a follow-up?
+- How to model complex multi-leg transactions (e.g., securities settlement) without overwhelming the base schema?
+- What minimal metadata is required for regulatory reporting (e.g., SAR/CTR thresholds) to keep the core ergonomic?
+
+These questions will be tracked in the plan document.

--- a/.specs/money/design.md
+++ b/.specs/money/design.md
@@ -27,6 +27,7 @@ packages/money/
       Mandate.ts
       Transfer.ts
       StandingInstruction.ts
+      Obligation.ts
       ExchangeRate.ts
       Common.ts (identifiers, enums, money amounts)
     Capability/
@@ -40,6 +41,7 @@ packages/money/
       Transactions.ts
       Transfers.ts
       StandingInstructions.ts
+      Obligations.ts
       Balances.ts
       Statements.ts
       Compliance.ts
@@ -60,6 +62,7 @@ packages/money/
 4. **Audit Fields**: Every entity includes `source`, `capturedAt`, `receivedAt`, `lastUpdatedAt`, and optional `provenance` objects describing the integration, API version, and credential reference.
 5. **Extension Slots**: Provide `extensions?: Schema.ReadonlyArray<ExtensionEnvelope>` where `ExtensionEnvelope` captures `{ namespace: Schema.NonEmptyString, data: Schema.JsonRecord }`, allowing institution-specific metadata without polluting the core schema.
 6. **Relationship References**: Use typed IDs and optional embedded summaries (e.g., `accountSummary?: AccountSummary`) to support efficient consumption without requiring secondary fetches.
+7. **Obligation Modeling**: Represent recurring obligations with normalized components (`ObligationTerm`, `ObligationCharge`, `UsageMeterReading`, `CoverageAsset`). Support fixed and floating schedules, evergreen commitments with renegotiation windows, debt amortization ladders, escrow-backed disbursements, and hybrid insurance-investment instruments by decomposing the obligation into commitments, pricing sources, and settlement instructions.
 
 ### Service Contracts
 
@@ -69,6 +72,7 @@ Each service module exports:
 - **Interface** describing operations with typed inputs/outputs (using `Effect` and `Stream`).
 - **Layer constructors** for composition (e.g., `InstitutionDirectory.layer`, `InstitutionDirectory.withClient`).
 - **Capability negotiation** functions enabling runtime checks (e.g., `hasCapability("transactions.streaming")`).
+- **Scenario primitives** for obligations (e.g., pricing snapshots, forecast generation) that allow applications to reconcile indefinite rent, consumption-indexed utilities, or insurance cash value adjustments with the same API surface.
 
 Example (pseudocode):
 
@@ -86,15 +90,17 @@ Error types (e.g., `InstitutionError`, `TransactionError`) extend `Data.TaggedEr
 
 The `Capability/descriptors.ts` module defines a hierarchical taxonomy:
 
-- **Domain** (`accounts`, `transactions`, `transfers`, `statements`, `fx`, `compliance`).
+- **Domain** (`accounts`, `transactions`, `transfers`, `statements`, `fx`, `compliance`, `obligations`).
 - **Features** (`realTime`, `historical`, `streaming`, `batch`, `sameDay`, `wire`, `ach`, `sepa`, etc.).
 - **Constraints** (limits, cutoff windows, supported currencies, jurisdictions).
+- Obligation features call out billing archetypes (`evergreen`, `term`, `balloon`, `metered`, `tieredPricing`, `indexLinked`, `coverageLinked`), tolerance policies (grace periods, dunning strategies), and settlement mechanisms (auto-debit, manual pay, escrow drawdown).
 
 Capabilities are modeled as schemas allowing drivers to advertise support, optionally including quantitative limits. Applications query capabilities before invoking services, enabling graceful degradation.
 
 ### Auditing & Observability
 
 - **Event schemas** describe standard events (`SyncStarted`, `SyncCompleted`, `TransferInitiated`, `TransferSettled`, `TransferFailed`, `MandateCreated`, `ConsentRevoked`).
+- Obligation events capture lifecycle transitions (`ObligationActivated`, `ObligationChargeForecasted`, `ObligationChargePosted`, `ObligationSatisfied`, `ObligationDelinquent`) along with pricing provenance (e.g., rate tables, meter readings, underwriting adjustments).
 - Services emit events via an optional `AuditEventSink` service defined in `@effect/money-storage`. Drivers depend on the sink but do not assume a specific implementation.
 
 ### Storage Abstractions

--- a/.specs/money/design.md
+++ b/.specs/money/design.md
@@ -21,6 +21,7 @@ packages/money/
       Party.ts
       Account.ts
       Instrument.ts
+      Asset.ts
       Transaction.ts
       Balance.ts
       Statement.ts
@@ -28,6 +29,11 @@ packages/money/
       Transfer.ts
       StandingInstruction.ts
       Obligation.ts
+      Offering.ts
+      Inventory.ts
+      Order.ts
+      Cart.ts
+      Wishlist.ts
       ExchangeRate.ts
       Common.ts (identifiers, enums, money amounts)
     Capability/
@@ -42,6 +48,10 @@ packages/money/
       Transfers.ts
       StandingInstructions.ts
       Obligations.ts
+      Catalog.ts
+      Inventory.ts
+      Orders.ts
+      Assets.ts
       Balances.ts
       Statements.ts
       Compliance.ts
@@ -63,6 +73,7 @@ packages/money/
 5. **Extension Slots**: Provide `extensions?: Schema.ReadonlyArray<ExtensionEnvelope>` where `ExtensionEnvelope` captures `{ namespace: Schema.NonEmptyString, data: Schema.JsonRecord }`, allowing institution-specific metadata without polluting the core schema.
 6. **Relationship References**: Use typed IDs and optional embedded summaries (e.g., `accountSummary?: AccountSummary`) to support efficient consumption without requiring secondary fetches.
 7. **Obligation Modeling**: Represent recurring obligations with normalized components (`ObligationTerm`, `ObligationCharge`, `UsageMeterReading`, `CoverageAsset`). Support fixed and floating schedules, evergreen commitments with renegotiation windows, debt amortization ladders, escrow-backed disbursements, and hybrid insurance-investment instruments by decomposing the obligation into commitments, pricing sources, and settlement instructions.
+8. **Asset & Commerce Modeling**: Model fungible and non-fungible assets with `AssetIdentity`, `AssetClassification`, and `AssetValuation` records, plus custody links to accounts or off-ledger storage. Offerings compose assets, services, fees, and incentives into sellable bundles, while `InventoryItem`, `OrderLine`, `CartEntry`, and `WishlistEntry` schemas share primitives for availability, personalization, entitlements, and lifecycle (reserved, fulfilled, cancelled, returned). This keeps coffee shop POS items, crypto tokens, SaaS plans, RPG loot, and collectible trades aligned on the same building blocks.
 
 ### Service Contracts
 
@@ -73,6 +84,7 @@ Each service module exports:
 - **Layer constructors** for composition (e.g., `InstitutionDirectory.layer`, `InstitutionDirectory.withClient`).
 - **Capability negotiation** functions enabling runtime checks (e.g., `hasCapability("transactions.streaming")`).
 - **Scenario primitives** for obligations (e.g., pricing snapshots, forecast generation) that allow applications to reconcile indefinite rent, consumption-indexed utilities, or insurance cash value adjustments with the same API surface.
+- **Commerce orchestrators** that let catalogs, carts, and orders compose with transfers or obligations—for example, a coffee shop POS capturing an order and settling via cash drawer reconciliation, a crypto dApp minting NFTs while triggering asset registry entries, or a game marketplace reserving digital loot and debiting an in-world wallet.
 
 Example (pseudocode):
 
@@ -90,10 +102,11 @@ Error types (e.g., `InstitutionError`, `TransactionError`) extend `Data.TaggedEr
 
 The `Capability/descriptors.ts` module defines a hierarchical taxonomy:
 
-- **Domain** (`accounts`, `transactions`, `transfers`, `statements`, `fx`, `compliance`, `obligations`).
+- **Domain** (`accounts`, `transactions`, `transfers`, `statements`, `fx`, `compliance`, `obligations`, `catalog`, `orders`, `assets`).
 - **Features** (`realTime`, `historical`, `streaming`, `batch`, `sameDay`, `wire`, `ach`, `sepa`, etc.).
 - **Constraints** (limits, cutoff windows, supported currencies, jurisdictions).
 - Obligation features call out billing archetypes (`evergreen`, `term`, `balloon`, `metered`, `tieredPricing`, `indexLinked`, `coverageLinked`), tolerance policies (grace periods, dunning strategies), and settlement mechanisms (auto-debit, manual pay, escrow drawdown).
+- Commerce features express catalog richness (bundles, configurable options, localized menus), inventory behavior (real-time reservations, batch restock windows, serialized goods), order flows (draft quotes, partial fulfillment, returns/exchanges, layaway), asset lifecycles (mint/burn, appreciation curves, depreciation schedules), and marketplace mechanics (commissions, escrow, royalties).
 
 Capabilities are modeled as schemas allowing drivers to advertise support, optionally including quantitative limits. Applications query capabilities before invoking services, enabling graceful degradation.
 
@@ -103,6 +116,22 @@ Capabilities are modeled as schemas allowing drivers to advertise support, optio
 - Obligation events capture lifecycle transitions (`ObligationActivated`, `ObligationChargeForecasted`, `ObligationChargePosted`, `ObligationSatisfied`, `ObligationDelinquent`) along with pricing provenance (e.g., rate tables, meter readings, underwriting adjustments).
 - Services emit events via an optional `AuditEventSink` service defined in `@effect/money-storage`. Drivers depend on the sink but do not assume a specific implementation.
 
+## Scenario Coverage Matrix
+
+To confirm the abstractions remain composable without overfitting, the design maps representative scenarios to schemas/services:
+
+- **Local coffee shop** – Uses `Offering`, `InventoryItem`, `Order`, and `CatalogService` for menu items, links tender to `TransferService` (card) or `Order` cash settlement adjustments, and records loyalty stamps as `Asset` balances.
+- **Cash-only local handyman** – Captures `Order` estimates and invoices, settles via `TransferOrder` flagged as `cash`, and tracks tool depreciation or gift card liabilities via `AssetRegistryService`.
+- **Crypto dApp** – Mints NFTs or governance tokens via `Asset` lifecycles, orchestrates smart-contract interactions through `TransferService` plus `ObligationService` (staking rewards) and `Order` flows for marketplace listings.
+- **Online merch store** – Manages `CatalogService`, `InventoryService`, `OrderLifecycleService`, and `StandingInstructionService` for subscriptions or pre-orders, with `Obligation` ties for payment plans.
+- **eBay sneaker flipping business** – Models consignments as `Order` with marketplace commissions, associates serialized sneakers as `Asset` with provenance, and records payouts via `TransferService`.
+- **SaaS with zero employees** – Represents plans as `Offering` plus `Obligation` for recurring billing, automates onboarding via `OnboardingService`, and tracks entitlements through `AssetRegistryService`.
+- **Personal finance app** – Aggregates institutions/accounts via `AccountAggregationService`, normalizes transactions, and surfaces obligations (bills, subscriptions) and carts/wish lists imported from commerce platforms.
+- **Bank app** – Uses full suite: `InstitutionDirectory`, `Account`, `Transaction`, `Transfer`, `Obligation`, `Catalog` for product cross-sell, and `Asset` for loyalty points or safe deposit inventory.
+- **Monopoly video game** – Treats in-game properties and chance cards as `Asset` entries, uses `Order` for trades, `TransferService` for bank payouts, and `ObligationService` for rent or mortgages.
+- **RPG in-world marketplace** – Employs `CatalogService` for NPC vendors, `OrderLifecycleService` for player trades, `AssetRegistryService` for unique loot, and `InventoryService` for respawn timers or crafting inputs.
+- **Pokémon card trading** – Records each card as non-fungible `Asset` with grading metadata, uses `Order` + `Transfer` for trades, and `Obligation` for consignment or layaway deals.
+
 ### Storage Abstractions
 
 `@effect/money-storage` defines interfaces for:
@@ -111,6 +140,9 @@ Capabilities are modeled as schemas allowing drivers to advertise support, optio
 - `SyncStateStore` – track cursors, last success timestamps, incremental sync state.
 - `TransferStore` – persist transfer instructions and state transitions for idempotency.
 - `AuditEventSink` – append-only store for audit events (e.g., Kafka, Postgres, file-based).
+- `CatalogStore` – optional cache for offerings, inventory availability, and personalized pricing rules.
+- `OrderStore` – persist carts, quotes, orders, and fulfillment checkpoints for omnichannel experiences (in-person + digital).
+- `AssetLedger` – track non-fungible registry metadata, custody changes, and entitlements when assets are off-core (vaulted, on-chain, or in-game).
 
 Each interface relies solely on `Effect` primitives and is optionally provided by applications or driver bundles.
 
@@ -121,12 +153,14 @@ Each interface relies solely on `Effect` primitives and is optionally provided b
 - Schema validation helpers to assert driver outputs conform to core schemas.
 - Standardized mock servers for verifying webhook handling and OAuth flows.
 - Harness utilities for running cross-driver test suites (e.g., verifying transactions streaming). This mirrors `@effect/platform/test` patterns.
+- Scenario packs that simulate commerce workflows (POS order, cash settlement, NFT mint + sale, recurring SaaS charge, game loot trade) so implementers can validate catalog/order/asset behaviors end-to-end alongside traditional finance flows.
 
 ## Extension Strategy
 
 - Drivers extend via the `extensions` field and may expose additional services in their own namespace (e.g., brokerage-specific order management). Core package remains stable.
 - Provide recommended naming for driver packages (`@effect/money-{institution|provider}`) and persistence packages (`@effect/money-storage-{backend}`).
 - Encourage cross-domain bridges (e.g., linking `@effect/platform` HTTP clients for driver communication).
+- Invite ecosystem modules for verticalized commerce (`@effect/money-commerce-pos`, `@effect/money-commerce-marketplace`, `@effect/money-gaming`) that plug into the same catalog/order/asset contracts while introducing additional scenario packs or capability descriptors.
 
 ## Open Questions
 

--- a/.specs/money/instructions.md
+++ b/.specs/money/instructions.md
@@ -1,0 +1,28 @@
+# @effect/money Specification: Instructions
+
+## Vision
+
+Design a modular suite of Effect packages that provides a universal, implementation-agnostic abstraction for working with consumer and enterprise financial data. Mirroring the patterns established by `@effect/platform`, the initiative must define the core domain interfaces, schemas, and behaviors while enabling ecosystem packages to supply concrete integrations for banks, brokerages, payment networks, accounting systems, and data providers.
+
+## Stakeholders
+
+- **Application engineers** building Effect applications that need reliable financial data access and actions (e.g., budgeting tools, accounting systems, treasury automation).
+- **Integration authors** who contribute `@effect/money-*` drivers for specific financial institutions, data providers, or persistence layers.
+- **Compliance and risk teams** that require auditable, strongly typed representations of financial operations.
+
+## Problem Statement
+
+The Effect ecosystem currently lacks a standardized domain model for financial resources and actions. Developers repeatedly re-invent schemas for accounts, instruments, transactions, transfers, and scheduled operations, making it difficult to compose integrations or swap providers. We need shared specifications that:
+
+1. **Normalize terminology** across retail banking, payments, brokerage, credit, and accounting domains.
+2. **Provide canonical schemas** covering the primary nouns (accounts, institutions, instruments, customers, mandates, transactions, balances, statements, standing orders, etc.).
+3. **Define core service abstractions** for common verbs (syncing accounts, executing transfers, reconciling balances, managing recurring operations, onboarding customers, etc.).
+4. **Support extensibility** so driver packages can specialize behavior without diverging from the core contract.
+
+## Deliverables for Specification Phase
+
+- A requirements breakdown capturing supported domains, data coverage, and service responsibilities.
+- A design document describing module layout, Effect services, schema definitions, and extension mechanisms.
+- A delivery plan enumerating milestones for introducing the packages and expanding coverage.
+
+Completion of the specification phase means stakeholders agree on the schemas, interfaces, and roadmap so implementation work can begin in separate follow-up specs or tasks.

--- a/.specs/money/plan.md
+++ b/.specs/money/plan.md
@@ -1,0 +1,55 @@
+# @effect/money Specification: Plan
+
+## Milestones
+
+### M1 – Specification Finalization
+- [ ] Review instructions, requirements, and design documents with Effect core maintainers and community financial-domain SMEs.
+- [ ] Resolve open questions regarding real-time payment coverage, multi-leg transaction modeling, and regulatory metadata.
+- [ ] Produce example JSON fixtures and schema diagrams for each core entity.
+- [ ] Publish capability taxonomy draft for community feedback.
+
+### M2 – Core Package Implementation (`@effect/money`)
+- [ ] Scaffold package structure and exports consistent with `@effect/platform` conventions.
+- [ ] Implement `Schema/Common` primitives and branded identifiers.
+- [ ] Implement entity schemas (Institution, Party, Account, Instrument, Transaction, Balance, Statement, Mandate, Transfer, StandingInstruction, ExchangeRate).
+- [ ] Implement capability descriptors and matrix utilities.
+- [ ] Define `Data.TaggedError` hierarchies for each service domain.
+- [ ] Define service interfaces with method signatures, capability negotiation helpers, and documentation.
+- [ ] Draft contract-test interfaces for downstream drivers.
+
+### M3 – Supporting Packages
+- [ ] Implement `@effect/money-client` with validation helpers, pagination utilities, and testing harness skeletons.
+- [ ] Implement `@effect/money-storage` interfaces (`CredentialStore`, `SyncStateStore`, `TransferStore`, `AuditEventSink`).
+- [ ] Provide mock/in-memory reference implementations for testing.
+- [ ] Document Layer composition examples for applications.
+
+### M4 – Pilot Driver & Persistence Integrations (Stretch Goal)
+- [ ] Choose one aggregator (e.g., Plaid sandbox) to validate account/transaction flows.
+- [ ] Build reference driver showcasing schema mappings, error handling, and capability declaration.
+- [ ] Implement example persistence adapter (e.g., SQLite or file-based) for stores.
+- [ ] Run contract test suite to verify compliance.
+
+## Workstreams
+
+1. **Schema Authoring** – Owns schema fidelity, invariants, and documentation. Coordinates with driver teams for coverage.
+2. **Service Contracts** – Defines Effect services, errors, and capability negotiation patterns. Ensures ergonomic layering.
+3. **Testing & Tooling** – Builds contract-test harness, fixtures, and developer experience utilities.
+4. **Compliance & Audit** – Ensures consent, jurisdiction, and audit requirements are captured across schemas and services.
+
+Each workstream will track tasks in the repository project board once the specification is accepted.
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Divergent institution data models make a single schema unwieldy | High | Provide extensible `extensions` envelopes and encourage optional fields; iterate with driver authors early. |
+| Regulatory requirements differ by region | Medium | Model jurisdiction metadata explicitly and allow pluggable compliance validators. |
+| Contract tests become too heavyweight for driver authors | Medium | Offer modular test suites and documented minimum compliance sets. |
+| Capability taxonomy drifts over time | Medium | Establish governance process (RFC or ADR) for introducing new capabilities. |
+
+## Next Actions
+
+- [ ] Schedule design review with platform maintainers.
+- [ ] Collect sample payloads from existing integrations (Plaid, Teller, Stripe Treasury, Wise, IBKR) for schema validation.
+- [ ] Draft contribution guide for prospective `@effect/money-*` driver authors.
+- [ ] Evaluate alignment with existing accounting standards (OFX, ISO 20022, NACHA) for terminology consistency.

--- a/.specs/money/plan.md
+++ b/.specs/money/plan.md
@@ -11,10 +11,11 @@
 ### M2 – Core Package Implementation (`@effect/money`)
 - [ ] Scaffold package structure and exports consistent with `@effect/platform` conventions.
 - [ ] Implement `Schema/Common` primitives and branded identifiers.
-- [ ] Implement entity schemas (Institution, Party, Account, Instrument, Transaction, Balance, Statement, Mandate, Transfer, StandingInstruction, Obligation, ExchangeRate).
+- [ ] Implement entity schemas (Institution, Party, Account, Instrument, Asset, Offering, Inventory, Transaction, Balance, Statement, Mandate, Transfer, StandingInstruction, Obligation, Order, Cart, Wishlist, ExchangeRate).
 - [ ] Implement capability descriptors and matrix utilities.
 - [ ] Define `Data.TaggedError` hierarchies for each service domain.
 - [ ] Define service interfaces with method signatures, capability negotiation helpers, and documentation.
+- [ ] Model commerce services (Catalog, Inventory, Orders, AssetRegistry) alongside existing financial services and document composition examples (e.g., POS checkout + transfer, NFT sale + obligation payoff).
 - [ ] Prototype obligation modeling playbooks that cover evergreen rent, consumption-indexed utilities, amortizing loans, tax escrows, and hybrid insurance-investment policies with shared abstractions.
 - [ ] Draft contract-test interfaces for downstream drivers.
 
@@ -23,7 +24,7 @@
 - [ ] Implement `@effect/money-storage` interfaces (`CredentialStore`, `SyncStateStore`, `TransferStore`, `AuditEventSink`).
 - [ ] Provide mock/in-memory reference implementations for testing.
 - [ ] Document Layer composition examples for applications.
-- [ ] Extend contract-test scenarios to include recurring obligation forecasting, reconciliation of billed vs. actual amounts, and lifecycle edge cases (delinquency, payoff, renegotiation).
+- [ ] Extend contract-test scenarios to include recurring obligation forecasting, reconciliation of billed vs. actual amounts, commerce flows (catalog browsing, cart mutation, serialized inventory, checkout, returns), and lifecycle edge cases (delinquency, payoff, renegotiation).
 
 ### M4 – Pilot Driver & Persistence Integrations (Stretch Goal)
 - [ ] Choose one aggregator (e.g., Plaid sandbox) to validate account/transaction flows.
@@ -37,6 +38,7 @@
 2. **Service Contracts** – Defines Effect services, errors, and capability negotiation patterns. Ensures ergonomic layering.
 3. **Testing & Tooling** – Builds contract-test harness, fixtures, and developer experience utilities.
 4. **Compliance & Audit** – Ensures consent, jurisdiction, and audit requirements are captured across schemas and services.
+5. **Commerce & Experience** – Curates catalog/order/asset scenarios, ensures fungible and non-fungible asset coverage, and validates gaming/marketplace/retail workflows against the shared abstractions.
 
 Each workstream will track tasks in the repository project board once the specification is accepted.
 
@@ -49,6 +51,7 @@ Each workstream will track tasks in the repository project board once the specif
 | Contract tests become too heavyweight for driver authors | Medium | Offer modular test suites and documented minimum compliance sets. |
 | Capability taxonomy drifts over time | Medium | Establish governance process (RFC or ADR) for introducing new capabilities. |
 | Obligation scenarios diverge across industries | Medium | Provide canonical obligation archetypes (subscription, utility, debt, insurance) with extension hooks and encourage driver-authored examples. |
+| Commerce breadth overwhelms implementers | Medium | Maintain scenario matrix to prioritize core primitives, gate additions via RFCs, and supply vertical sample mappings (retail, services, gaming, DeFi). |
 
 ## Next Actions
 
@@ -57,3 +60,4 @@ Each workstream will track tasks in the repository project board once the specif
 - [ ] Draft contribution guide for prospective `@effect/money-*` driver authors.
 - [ ] Evaluate alignment with existing accounting standards (OFX, ISO 20022, NACHA) for terminology consistency.
 - [ ] Research regulatory guidance for billing and insurance obligations (FTC recurring billing rules, PSD2 SCA for subscriptions, NAIC standards) to inform schema fields.
+- [ ] Assemble scenario playbooks for retail, services, crypto, gaming, and collectibles to validate the schema/service matrix and identify potential gaps early.

--- a/.specs/money/plan.md
+++ b/.specs/money/plan.md
@@ -11,10 +11,11 @@
 ### M2 – Core Package Implementation (`@effect/money`)
 - [ ] Scaffold package structure and exports consistent with `@effect/platform` conventions.
 - [ ] Implement `Schema/Common` primitives and branded identifiers.
-- [ ] Implement entity schemas (Institution, Party, Account, Instrument, Transaction, Balance, Statement, Mandate, Transfer, StandingInstruction, ExchangeRate).
+- [ ] Implement entity schemas (Institution, Party, Account, Instrument, Transaction, Balance, Statement, Mandate, Transfer, StandingInstruction, Obligation, ExchangeRate).
 - [ ] Implement capability descriptors and matrix utilities.
 - [ ] Define `Data.TaggedError` hierarchies for each service domain.
 - [ ] Define service interfaces with method signatures, capability negotiation helpers, and documentation.
+- [ ] Prototype obligation modeling playbooks that cover evergreen rent, consumption-indexed utilities, amortizing loans, tax escrows, and hybrid insurance-investment policies with shared abstractions.
 - [ ] Draft contract-test interfaces for downstream drivers.
 
 ### M3 – Supporting Packages
@@ -22,6 +23,7 @@
 - [ ] Implement `@effect/money-storage` interfaces (`CredentialStore`, `SyncStateStore`, `TransferStore`, `AuditEventSink`).
 - [ ] Provide mock/in-memory reference implementations for testing.
 - [ ] Document Layer composition examples for applications.
+- [ ] Extend contract-test scenarios to include recurring obligation forecasting, reconciliation of billed vs. actual amounts, and lifecycle edge cases (delinquency, payoff, renegotiation).
 
 ### M4 – Pilot Driver & Persistence Integrations (Stretch Goal)
 - [ ] Choose one aggregator (e.g., Plaid sandbox) to validate account/transaction flows.
@@ -46,6 +48,7 @@ Each workstream will track tasks in the repository project board once the specif
 | Regulatory requirements differ by region | Medium | Model jurisdiction metadata explicitly and allow pluggable compliance validators. |
 | Contract tests become too heavyweight for driver authors | Medium | Offer modular test suites and documented minimum compliance sets. |
 | Capability taxonomy drifts over time | Medium | Establish governance process (RFC or ADR) for introducing new capabilities. |
+| Obligation scenarios diverge across industries | Medium | Provide canonical obligation archetypes (subscription, utility, debt, insurance) with extension hooks and encourage driver-authored examples. |
 
 ## Next Actions
 
@@ -53,3 +56,4 @@ Each workstream will track tasks in the repository project board once the specif
 - [ ] Collect sample payloads from existing integrations (Plaid, Teller, Stripe Treasury, Wise, IBKR) for schema validation.
 - [ ] Draft contribution guide for prospective `@effect/money-*` driver authors.
 - [ ] Evaluate alignment with existing accounting standards (OFX, ISO 20022, NACHA) for terminology consistency.
+- [ ] Research regulatory guidance for billing and insurance obligations (FTC recurring billing rules, PSD2 SCA for subscriptions, NAIC standards) to inform schema fields.

--- a/.specs/money/requirements.md
+++ b/.specs/money/requirements.md
@@ -24,9 +24,11 @@ The specification must remain implementation-agnostic while being rich enough fo
   - **Mandate / Authorization** (ACH authorization, SEPA mandate, card-on-file consent, trading power of attorney).
   - **Transfer Order** (one-off transfers, recurring schedules, approval workflows).
   - **Standing Instruction / Recurring Operation** (frequency, schedule, execution rules, retry policy).
+  - **Obligation / Billing Arrangement** (open-ended recurring charges, term-limited payment plans, debt amortization schedules, coverage or utility usage meters, variable pricing formulas, settlement destinations).
   - **Exchange Rate Quote** (source, timestamp, base/quote currency, rate type, spreads).
 - Schemas must capture status enums, references between entities, and auditing metadata (created/updated timestamps, versioning, provenance).
 - Provide extensibility hooks (e.g., `extensions?: Schema.Record<string, Schema.Json>` or branded `Unknown` fields) to allow driver-specific metadata while keeping the base schema immutable.
+- Recurring obligations must express recurrence cadence (calendar-anchored, usage-triggered, event-driven), pricing dimensions (fixed, tiered, index-linked, consumption-based), lifecycle (initiated, active, suspended, satisfied, defaulted), payoff math (amortized principal, interest accrual, balloon payments), and relationships to collateral or coverage assets (e.g., insurance cash value, prepaid balances).
 
 ### 2. Service Abstractions
 - Define Effect services for the following capability areas, each with explicit error models:
@@ -35,6 +37,7 @@ The specification must remain implementation-agnostic while being rich enough fo
   - **TransactionService** for paging, streaming, and reconciling transactions.
   - **TransferService** for initiating, tracking, and cancelling transfers.
   - **StandingInstructionService** for CRUD on recurring payments/transfers.
+  - **ObligationService** for managing recurring billing arrangements, forecasting expected charges, updating payment schedules, and reconciling obligations against actual payments.
   - **BalanceService** for real-time balance snapshots and historical balance timelines.
   - **StatementService** for retrieving statements and documents.
   - **ComplianceService** for managing mandates, consents, and regulatory evidence.
@@ -64,6 +67,7 @@ The specification must remain implementation-agnostic while being rich enough fo
 
 - **Consistency**: Align naming, module layout, and service patterns with `@effect/platform` to minimize cognitive load.
 - **Extensibility**: Support domain-specific extensions (treasury, wealth management, insurance) without breaking core contracts.
+- **Scenario Diversity**: Explicitly model unconventional obligations (usage-indexed utilities, debt repayment plans, hybrid insurance-investment policies, tax withholdings, subscriptions with rollover benefits) so driver authors can represent industry-specific billing constructs without resorting to vendor-specific fields.
 - **Internationalization**: Schemas must be currency-agnostic, support multiple locales, and allow varying identifier formats (IBAN, routing/account, SWIFT, IFSC, etc.).
 - **Observability**: Define events/logging expectations for critical operations (sync start/finish, transfer status change, compliance events).
 - **Performance**: Provide guidance on batching, pagination, streaming, and rate-limit handling to ensure scalable drivers.

--- a/.specs/money/requirements.md
+++ b/.specs/money/requirements.md
@@ -1,0 +1,82 @@
+# @effect/money Specification: Requirements
+
+## Scope
+
+Define the foundational abstractions for a suite of financial-domain packages that parallels the structure of `@effect/platform`. The requirements cover:
+
+1. **Core package (`@effect/money`)** providing canonical schemas, data models, and service interfaces for financial operations.
+2. **Driver interface guidance** enabling implementation packages (`@effect/money-*`) to integrate with financial institutions, payment processors, accounting systems, and data warehouses.
+3. **Cross-cutting concerns** such as identity, consent, compliance metadata, reconciliation, and auditing.
+
+The specification must remain implementation-agnostic while being rich enough for downstream packages to map real-world APIs without ambiguity.
+
+## Functional Requirements
+
+### 1. Canonical Data Schemas
+- Provide normalized schemas using `@effect/schema/Schema` for the following core domains:
+  - **Institution** (financial institution metadata, capabilities, compliance constraints).
+  - **Party** (person or organization, KYC/KYB attributes, risk profile).
+  - **Account** (account identifiers, type classifications, currency, balances, ownership, access scopes).
+  - **Instrument** (cards, loans, investment products, insurance policies, digital assets).
+  - **Transaction** (ledger movements, status lifecycle, categorizations, reconciliation state, exchange rate context).
+  - **Balance Snapshot** (available, current, credit limit, accrued interest, valuation timestamps).
+  - **Statement** (periodic statements, line items, running balances, document metadata).
+  - **Mandate / Authorization** (ACH authorization, SEPA mandate, card-on-file consent, trading power of attorney).
+  - **Transfer Order** (one-off transfers, recurring schedules, approval workflows).
+  - **Standing Instruction / Recurring Operation** (frequency, schedule, execution rules, retry policy).
+  - **Exchange Rate Quote** (source, timestamp, base/quote currency, rate type, spreads).
+- Schemas must capture status enums, references between entities, and auditing metadata (created/updated timestamps, versioning, provenance).
+- Provide extensibility hooks (e.g., `extensions?: Schema.Record<string, Schema.Json>` or branded `Unknown` fields) to allow driver-specific metadata while keeping the base schema immutable.
+
+### 2. Service Abstractions
+- Define Effect services for the following capability areas, each with explicit error models:
+  - **InstitutionDirectoryService** for discovery of supported institutions and capabilities.
+  - **AccountAggregationService** for linking, refreshing, and revoking account connections.
+  - **TransactionService** for paging, streaming, and reconciling transactions.
+  - **TransferService** for initiating, tracking, and cancelling transfers.
+  - **StandingInstructionService** for CRUD on recurring payments/transfers.
+  - **BalanceService** for real-time balance snapshots and historical balance timelines.
+  - **StatementService** for retrieving statements and documents.
+  - **ComplianceService** for managing mandates, consents, and regulatory evidence.
+  - **OnboardingService** for customer enrollment, KYC document collection, and account opening workflows.
+  - **ExchangeRateService** for currency conversion quotes and settlement rates.
+- Each service must specify capability detection (e.g., via `Effect` returning `Option<Capability>`), streaming vs. batch data retrieval, and idempotency expectations.
+- Errors must use `Data.TaggedError` hierarchies with common discriminators (`type`, `reason`, `institutionId`, etc.).
+
+### 3. Capability Modeling
+- Introduce a capability description model that drivers use to declare supported features (e.g., `supportsRealTimeBalances`, `transferLimits`, `statementFormats`).
+- Provide guidance on fallback behavior when capabilities are absent (e.g., degrade to batch sync, raise `CapabilityUnavailableError`).
+
+### 4. Security & Compliance Metadata
+- Require tracking of consent scopes, validity periods, and revocation metadata on all sensitive operations.
+- Include audit trails for data fetches and state changes (who performed the action, with which credentials, and correlation IDs).
+- Ensure schemas accommodate jurisdictional metadata (e.g., PSD2, NACHA, FINRA obligations).
+
+### 5. Persistence & State Expectations
+- Describe minimal persistence contracts that a driver or host application might need (token storage, cursor checkpoints, scheduling state).
+- Define interfaces for pluggable storage abstractions (e.g., `CredentialStore`, `SyncStateStore`) without prescribing specific databases.
+
+### 6. Testing & Validation Requirements
+- Provide contract-test guidance that driver packages must satisfy (e.g., test harness for transaction sync, transfer execution, failure scenarios).
+- Require example JSON payloads for each schema with validation rules and invariants to aid implementers.
+
+## Non-Functional Requirements
+
+- **Consistency**: Align naming, module layout, and service patterns with `@effect/platform` to minimize cognitive load.
+- **Extensibility**: Support domain-specific extensions (treasury, wealth management, insurance) without breaking core contracts.
+- **Internationalization**: Schemas must be currency-agnostic, support multiple locales, and allow varying identifier formats (IBAN, routing/account, SWIFT, IFSC, etc.).
+- **Observability**: Define events/logging expectations for critical operations (sync start/finish, transfer status change, compliance events).
+- **Performance**: Provide guidance on batching, pagination, streaming, and rate-limit handling to ensure scalable drivers.
+- **Security**: Encourage encryption-at-rest for persisted secrets, token rotation, and principle of least privilege in capability modeling.
+
+## Out of Scope
+
+- Implementing concrete drivers or persistence adapters (handled in follow-up specs/tasks).
+- Defining UI/UX components or rendering concerns.
+- Building business-specific rules (e.g., budgeting categories) beyond generic schema slots.
+
+## Acceptance Criteria
+
+- Requirements document reviewed by core stakeholders with agreement on nouns, verbs, and constraints.
+- Traceability matrix linking each service abstraction to one or more schemas and capability descriptions.
+- Identified open questions or research tasks captured in the plan document.

--- a/.specs/money/requirements.md
+++ b/.specs/money/requirements.md
@@ -18,6 +18,8 @@ The specification must remain implementation-agnostic while being rich enough fo
   - **Party** (person or organization, KYC/KYB attributes, risk profile).
   - **Account** (account identifiers, type classifications, currency, balances, ownership, access scopes).
   - **Instrument** (cards, loans, investment products, insurance policies, digital assets).
+  - **Asset** (fungible currencies, commodities, loyalty points, reward balances, and non-fungible collectibles with provenance,
+    grading, or minting metadata for scenarios like rare sneakers, Pokémon cards, NFTs, or in-game artifacts).
   - **Transaction** (ledger movements, status lifecycle, categorizations, reconciliation state, exchange rate context).
   - **Balance Snapshot** (available, current, credit limit, accrued interest, valuation timestamps).
   - **Statement** (periodic statements, line items, running balances, document metadata).
@@ -25,10 +27,15 @@ The specification must remain implementation-agnostic while being rich enough fo
   - **Transfer Order** (one-off transfers, recurring schedules, approval workflows).
   - **Standing Instruction / Recurring Operation** (frequency, schedule, execution rules, retry policy).
   - **Obligation / Billing Arrangement** (open-ended recurring charges, term-limited payment plans, debt amortization schedules, coverage or utility usage meters, variable pricing formulas, settlement destinations).
+  - **Product / Service Offering** (catalog entries for goods, services, subscriptions, bundles, deposits, add-ons, and virtual items with pricing tiers, packaging, regulatory constraints, fulfillment channels, and revenue recognition hints).
+  - **Inventory Position** (stock levels, reservable quantities, serial numbers, condition grading, edition/lot tracking for physical or digital goods, and custody or warehouse location references for remote fulfillment).
+  - **Order / Invoice** (line items referencing offerings, obligations, or assets, applied discounts/fees/taxes, fulfillment status, shipping/hand-off plans, and settlement references to payments or transfers).
+  - **Shopping Session Artifact** (quotes, carts, wish lists, configured bundles, saved tender preferences, and partially executed checkouts that can be converted into orders, obligations, or standing instructions).
   - **Exchange Rate Quote** (source, timestamp, base/quote currency, rate type, spreads).
 - Schemas must capture status enums, references between entities, and auditing metadata (created/updated timestamps, versioning, provenance).
 - Provide extensibility hooks (e.g., `extensions?: Schema.Record<string, Schema.Json>` or branded `Unknown` fields) to allow driver-specific metadata while keeping the base schema immutable.
 - Recurring obligations must express recurrence cadence (calendar-anchored, usage-triggered, event-driven), pricing dimensions (fixed, tiered, index-linked, consumption-based), lifecycle (initiated, active, suspended, satisfied, defaulted), payoff math (amortized principal, interest accrual, balloon payments), and relationships to collateral or coverage assets (e.g., insurance cash value, prepaid balances).
+- Commerce artifacts must express fungibility, divisibility, and uniqueness constraints; attach valuation sources and provenance (issuer, grading/certification body, minting/edition identifiers, serial numbers); and allow linking to custody accounts or escrow arrangements so game economies, collectible marketplaces, and cash-based merchants can share the same primitives.
 
 ### 2. Service Abstractions
 - Define Effect services for the following capability areas, each with explicit error models:
@@ -38,6 +45,9 @@ The specification must remain implementation-agnostic while being rich enough fo
   - **TransferService** for initiating, tracking, and cancelling transfers.
   - **StandingInstructionService** for CRUD on recurring payments/transfers.
   - **ObligationService** for managing recurring billing arrangements, forecasting expected charges, updating payment schedules, and reconciling obligations against actual payments.
+  - **CatalogService** for browsing offerings, pricing variants, bundles, and availability windows.
+  - **OrderLifecycleService** for managing carts, quotes, checkout orchestration, order capture, fulfillment updates, returns, and linkage to payment or transfer intents.
+  - **AssetRegistryService** for resolving fungible/non-fungible asset metadata, entitlements, vesting, mint/burn events, depreciation schedules, and custody relationships.
   - **BalanceService** for real-time balance snapshots and historical balance timelines.
   - **StatementService** for retrieving statements and documents.
   - **ComplianceService** for managing mandates, consents, and regulatory evidence.
@@ -49,6 +59,7 @@ The specification must remain implementation-agnostic while being rich enough fo
 ### 3. Capability Modeling
 - Introduce a capability description model that drivers use to declare supported features (e.g., `supportsRealTimeBalances`, `transferLimits`, `statementFormats`).
 - Provide guidance on fallback behavior when capabilities are absent (e.g., degrade to batch sync, raise `CapabilityUnavailableError`).
+- Extend the taxonomy with commerce and experience facets (catalog depth, inventory reservations, customization rules, cart persistence, offer personalization, entitlement issuance, loyalty accrual, secondary-market resale permissions) so applications can negotiate features across consumer retail, professional services, gaming marketplaces, DeFi, and collectibles trading.
 
 ### 4. Security & Compliance Metadata
 - Require tracking of consent scopes, validity periods, and revocation metadata on all sensitive operations.
@@ -61,13 +72,14 @@ The specification must remain implementation-agnostic while being rich enough fo
 
 ### 6. Testing & Validation Requirements
 - Provide contract-test guidance that driver packages must satisfy (e.g., test harness for transaction sync, transfer execution, failure scenarios).
+- Define scenario-driven validation suites covering local retail POS, cash-only settlements, crypto smart-contract obligations, online retail carts, marketplace consignments, SaaS subscriptions, personal finance aggregation, bank core ledgers, simulation games, RPG economies, and collectible exchanges to prevent over/under abstraction.
 - Require example JSON payloads for each schema with validation rules and invariants to aid implementers.
 
 ## Non-Functional Requirements
 
 - **Consistency**: Align naming, module layout, and service patterns with `@effect/platform` to minimize cognitive load.
 - **Extensibility**: Support domain-specific extensions (treasury, wealth management, insurance) without breaking core contracts.
-- **Scenario Diversity**: Explicitly model unconventional obligations (usage-indexed utilities, debt repayment plans, hybrid insurance-investment policies, tax withholdings, subscriptions with rollover benefits) so driver authors can represent industry-specific billing constructs without resorting to vendor-specific fields.
+- **Scenario Diversity**: Explicitly model unconventional obligations (usage-indexed utilities, debt repayment plans, hybrid insurance-investment policies, tax withholdings, subscriptions with rollover benefits) so driver authors can represent industry-specific billing constructs without resorting to vendor-specific fields. Extend the same rigor to commerce concepts (perishable inventory, digital entitlements, configurable bundles, tipping, marketplace commissions, secondary-market resales) so the core schema remains a superset of consumer retail, professional services, gaming, and DeFi ecosystems.
 - **Internationalization**: Schemas must be currency-agnostic, support multiple locales, and allow varying identifier formats (IBAN, routing/account, SWIFT, IFSC, etc.).
 - **Observability**: Define events/logging expectations for critical operations (sync start/finish, transfer status change, compliance events).
 - **Performance**: Provide guidance on batching, pagination, streaming, and rate-limit handling to ensure scalable drivers.
@@ -84,3 +96,4 @@ The specification must remain implementation-agnostic while being rich enough fo
 - Requirements document reviewed by core stakeholders with agreement on nouns, verbs, and constraints.
 - Traceability matrix linking each service abstraction to one or more schemas and capability descriptions.
 - Identified open questions or research tasks captured in the plan document.
+- Documented scenario mapping showing how representative use cases (local coffee shop, cash-only handyman, crypto dApp, online merch store, sneaker flipping marketplace, lean SaaS, personal finance aggregator, bank core, Monopoly-style simulation, RPG marketplace, collectible trading) compose the canonical schemas and services without extra bespoke contracts.


### PR DESCRIPTION
## Summary
- introduce the @effect/money specification directory with instructions, requirements, design, and plan documents
- outline canonical financial schemas, service abstractions, and capability taxonomy modeled after @effect/platform
- document the milestone roadmap and workstreams for delivering core, client, and storage packages

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f827b68834832f90e7be0569c806d6