### PR TITLE
Add wish/wrapper control plane CLI package

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@effect/docgen": "^0.4.7",
     "@effect/eslint-plugin": "^0.3.2",
     "@effect/language-service": "^0.23.5",
+    "@effect-native/wrp": "workspace:*",
     "@effect/vitest": "latest",
     "@eslint/compat": "^1.3.2",
     "@eslint/eslintrc": "^3.3.1",

--- a/packages-native/wrp/README.md
+++ b/packages-native/wrp/README.md
@@ -1,0 +1,23 @@
+# @effect-native/wrp
+
+Minimal wish/wrapper control-plane CLI for promptgraph workspaces. The `wrp` binary manages markdown-backed wishes so teams can capture tasks and evaluate them quickly.
+
+## Usage
+
+Run commands from the root of a wrapper workspace (any directory on disk):
+
+```bash
+pnpm wrp init
+pnpm wrp add wish "Review PR 123"
+pnpm wrp list --tag=tomorrow
+pnpm wrp eval w-use-system-tomorrow
+```
+
+### Commands
+
+- `wrp init` – create the `promptgraph/` and `targets/` layout plus a starter wish.
+- `wrp add wish [title]` – add a new wish, optionally prompting for a title.
+- `wrp list [--tag=tag] [--status=status]` – list wishes filtered by kind, tag, or status.
+- `wrp show <id>` – show a node’s frontmatter and body.
+- `wrp eval <id>` – walk through manual evaluation steps and update `claimStatus`.
+- `wrp repo list` – list configured external repositories from `targets/repos.yaml`.

--- a/packages-native/wrp/bin/wrp.js
+++ b/packages-native/wrp/bin/wrp.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import { register } from "tsx/esm/api"
+
+await register({})
+
+await import("../src/bin.ts")

--- a/packages-native/wrp/package.json
+++ b/packages-native/wrp/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@effect-native/wrp",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "description": "Minimal wish/wrapper CLI for promptgraph workspaces",
+  "bin": {
+    "wrp": "./bin/wrp.js"
+  },
+  "homepage": "https://github.com/effect-native/effect-native",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/effect-native/effect-native.git",
+    "directory": "packages-native/wrp"
+  },
+  "bugs": {
+    "url": "https://github.com/effect-native/effect-native/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "directory": "dist",
+    "linkDirectory": false
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./cli": "./src/cli.ts",
+    "./internal/*": null
+  },
+  "scripts": {
+    "codegen": "echo '@effect-native/wrp: nothing to codegen'",
+    "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3",
+    "build-esm": "tsc -b tsconfig.build.json",
+    "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
+    "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest --coverage"
+  },
+  "dependencies": {
+    "@effect/cli": "^0.71.0",
+    "@effect/platform": "^0.91.1",
+    "@effect/platform-node": "^0.97.1",
+    "effect": "^3.18.4",
+    "tsx": "^4.20.5",
+    "yaml": "^2.5.1"
+  },
+  "devDependencies": {
+    "@effect/vitest": "latest"
+  },
+  "effect": {
+    "generateIndex": {
+      "include": [
+        "**/*"
+      ]
+    }
+  }
+}

--- a/packages-native/wrp/src/bin.ts
+++ b/packages-native/wrp/src/bin.ts
@@ -1,0 +1,10 @@
+import * as NodeRuntime from "@effect/platform-node/NodeRuntime"
+import * as Effect from "effect/Effect"
+import { cliLayers, wrpCli } from "./cli.js"
+
+Effect.suspend(() => wrpCli(process.argv)).pipe(
+  Effect.tapErrorCause(Effect.logError),
+  Effect.provide(cliLayers),
+  (effect) => effect,
+  NodeRuntime.runMain
+)

--- a/packages-native/wrp/src/cli.ts
+++ b/packages-native/wrp/src/cli.ts
@@ -1,0 +1,193 @@
+import { Args, Command, HelpDoc, Options } from "@effect/cli"
+import * as CliConfig from "@effect/cli/CliConfig"
+import { NodeContext } from "@effect/platform-node"
+import * as Console from "effect/Console"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
+import { addWish, evaluateManual, findNode, initWorkspace, listNodes, printTable } from "./core.js"
+import { loadConfig } from "./config.js"
+import packageJson from "../package.json" with { type: "json" }
+import { runEvaluationPrompt, runInputPrompt, showNodeDetails } from "./interactive.js"
+import { loadTargets } from "./targets.js"
+import { openInEditor } from "./editor.js"
+
+const version = packageJson.version as string
+
+const initCommand = Command.make("init", {}, () =>
+  Effect.gen(function*() {
+    const cwd = process.cwd()
+    const result = yield* initWorkspace(cwd)
+    if (result.created.length === 0) {
+      yield* Console.log("No changes needed. Workspace already initialized.")
+      return
+    }
+    yield* Console.log("Created:")
+    for (const entry of result.created) {
+      yield* Console.log(`- ${entry}`)
+    }
+  })).pipe(
+  Command.withDescription(HelpDoc.p("Initialize the local promptgraph workspace"))
+)
+
+const addWishCommand = Command.make(
+  "wish",
+  {
+    title: Args.optional(Args.text({ name: "title" })),
+    tags: Options.repeated(Options.text("tag"))
+  },
+  ({ title, tags }) =>
+    Effect.gen(function*() {
+      const resolvedTitle = yield* Option.match(title, {
+        onSome: (value) => Effect.succeed(value),
+        onNone: () => runInputPrompt("Enter a title for the wish:")
+      })
+      const resolvedTags = tags
+      const { wish, filePath } = yield* addWish(process.cwd(), resolvedTitle, resolvedTags)
+      yield* Console.log(`Created wish ${wish.id}`)
+      yield* Console.log(`Path: ${filePath}`)
+      const editor = process.env.EDITOR
+      if (editor && editor.length > 0) {
+        yield* Console.log(`Opening in ${editor}...`)
+        yield* openInEditor(editor, filePath)
+      }
+    })
+).pipe(
+  Command.withDescription(HelpDoc.p("Create a new wish node"))
+)
+
+const addCommand = Command.make("add").pipe(
+  Command.withDescription(HelpDoc.p("Add nodes to the promptgraph")),
+  Command.withSubcommands([addWishCommand])
+)
+
+const listCommand = Command.make(
+  "list",
+  {
+    kind: Options.text("kind").pipe(Options.withDefault("wish")),
+    tag: Options.optional(Options.text("tag")),
+    status: Options.optional(Options.text("status"))
+  },
+  ({ kind, tag, status }) =>
+    Effect.gen(function*() {
+      const nodes = yield* listNodes(process.cwd(), {
+        kind,
+        tag: Option.getOrUndefined(tag),
+        status: Option.getOrUndefined(status)
+      })
+      yield* printTable(nodes)
+    })
+).pipe(
+  Command.withDescription(HelpDoc.p("List nodes filtered by kind, tag, or status"))
+)
+
+const showCommand = Command.make(
+  "show",
+  {
+    id: Args.text({ name: "id" })
+  },
+  ({ id }) =>
+    Effect.gen(function*() {
+      const node = yield* findNode(process.cwd(), id)
+      if (!node) {
+        yield* Console.log(`No node found with id ${id}`)
+        const suggestions = yield* listNodes(process.cwd(), {})
+        const nearMatches = suggestions
+          .filter((candidate) => candidate.id.includes(id))
+          .map((candidate) => candidate.id)
+        if (nearMatches.length > 0) {
+          yield* Console.log("Did you mean:")
+          for (const suggestion of nearMatches) {
+            yield* Console.log(`- ${suggestion}`)
+          }
+        }
+        return
+      }
+      yield* showNodeDetails(node)
+    })
+).pipe(
+  Command.withDescription(HelpDoc.p("Display a node with its frontmatter and body"))
+)
+
+const evalCommand = Command.make(
+  "eval",
+  {
+    id: Args.text({ name: "id" })
+  },
+  ({ id }) =>
+    Effect.gen(function*() {
+      const node = yield* findNode(process.cwd(), id)
+      if (!node) {
+        yield* Console.log(`No node found with id ${id}`)
+        return
+      }
+
+      if (!node.evaluation) {
+        yield* Console.log("No evaluation spec defined.")
+        return
+      }
+
+      if (node.evaluation.reproLevel !== "manual-human") {
+        yield* Console.log("Only manual-human evaluations are supported in this version.")
+        return
+      }
+
+      yield* runEvaluationPrompt(node)
+      const response = yield* runInputPrompt("Did this claim pass? (y/n/i)")
+      const decision = response.trim().toLowerCase()
+      if (decision !== "y" && decision !== "n" && decision !== "i") {
+        yield* Console.log("Invalid response. Expected y, n, or i.")
+        return
+      }
+
+      const { updated, logPath } = yield* evaluateManual(process.cwd(), node, decision as "y" | "n" | "i")
+      yield* Console.log(`Updated claimStatus to ${updated.claimStatus}`)
+      yield* Console.log(`Logged run to ${logPath}`)
+    })
+).pipe(
+  Command.withDescription(HelpDoc.p("Run a manual-human evaluation for a node"))
+)
+
+const repoListCommand = Command.make("list", {}, () =>
+  Effect.gen(function*() {
+    const config = yield* loadConfig(process.cwd())
+    const targets = yield* loadTargets(process.cwd(), config)
+    if (targets.repos.length === 0) {
+      yield* Console.log("No target repositories configured.")
+      return
+    }
+    for (const repo of targets.repos) {
+      yield* Console.log(`${repo.id}: ${repo.remote} (${repo.localRoot}) [${repo.defaultBranch}]`)
+    }
+  })
+).pipe(
+  Command.withDescription(HelpDoc.p("List configured external repositories"))
+)
+
+const repoCommand = Command.make("repo").pipe(
+  Command.withDescription(HelpDoc.p("Manage repository mappings")),
+  Command.withSubcommands([repoListCommand])
+)
+
+export const wrpCommand = Command.make("wrp").pipe(
+  Command.withDescription(HelpDoc.p("Wish/wrapper CLI")),
+  Command.withSubcommands([
+    initCommand,
+    addCommand,
+    listCommand,
+    showCommand,
+    evalCommand,
+    repoCommand
+  ])
+)
+
+export const cliLayers = Layer.mergeAll(
+  CliConfig.layer({ showBuiltIns: false }),
+  NodeContext.layer
+)
+
+export const wrpCli = Command.run(wrpCommand, {
+  name: "wrp",
+  version,
+  summary: HelpDoc.p("Lightweight wish/wrapper control plane")
+})

--- a/packages-native/wrp/src/config.ts
+++ b/packages-native/wrp/src/config.ts
@@ -1,0 +1,46 @@
+import { promises as fs } from "node:fs"
+import path from "node:path"
+import * as Effect from "effect/Effect"
+
+export type WrpConfig = {
+  promptgraphDir: string
+  targetsDir: string
+}
+
+export const defaultConfig: WrpConfig = {
+  promptgraphDir: "promptgraph",
+  targetsDir: "targets"
+}
+
+const readConfigFile = (configPath: string) =>
+  Effect.tryPromise({
+    try: () => fs.readFile(configPath, "utf8"),
+    catch: (error) => error as Error
+  })
+
+export const loadConfig = (rootDir: string): Effect.Effect<WrpConfig> =>
+  Effect.gen(function*() {
+    const configPath = path.join(rootDir, "wrp.config.json")
+    const exists = yield* Effect.tryPromise({
+      try: () => fs.access(configPath).then(() => true).catch(() => false),
+      catch: (error) => error as Error
+    })
+
+    if (!exists) {
+      return defaultConfig
+    }
+
+    const content = yield* readConfigFile(configPath)
+    const parsed = JSON.parse(content) as Partial<WrpConfig>
+
+    return {
+      ...defaultConfig,
+      ...parsed
+    }
+  })
+
+export const writeDefaultConfig = (rootDir: string, config: WrpConfig = defaultConfig) =>
+  Effect.tryPromise({
+    try: () => fs.writeFile(path.join(rootDir, "wrp.config.json"), `${JSON.stringify(config, null, 2)}\n`, "utf8"),
+    catch: (error) => error as Error
+  })

--- a/packages-native/wrp/src/core.ts
+++ b/packages-native/wrp/src/core.ts
@@ -1,0 +1,298 @@
+import { promises as fs } from "node:fs"
+import path from "node:path"
+import * as Console from "effect/Console"
+import * as Effect from "effect/Effect"
+import * as Random from "effect/Random"
+import { defaultConfig, loadConfig, type WrpConfig, writeDefaultConfig } from "./config.js"
+import { loadAllNodes, nodeFilePath, readNodeById, writeNode } from "./fsNodes.js"
+import { type AnyNode, type ClaimStatus, type WishNode } from "./model.js"
+
+const fileExists = (filePath: string) =>
+  Effect.tryPromise({
+    try: () => fs.access(filePath).then(() => true).catch(() => false),
+    catch: (error) => error as Error
+  })
+
+const ensureDir = (dir: string) =>
+  Effect.tryPromise({
+    try: () => fs.mkdir(dir, { recursive: true }),
+    catch: (error) => error as Error
+  })
+
+const writeFile = (filePath: string, content: string) =>
+  Effect.tryPromise({
+    try: () => fs.writeFile(filePath, content, "utf8"),
+    catch: (error) => error as Error
+  })
+
+const defaultManualEvaluation = {
+  reproLevel: "manual-human" as const,
+  manual: {
+    timeBudgetMinutes: 5,
+    difficulty: "easy" as const,
+    steps: [
+      {
+        description: "Later, decide whether this wish has been meaningfully addressed.",
+        expected: "You can honestly say yes or no."
+      }
+    ]
+  }
+}
+
+const rootWish = (): WishNode => ({
+  id: "w-use-system-tomorrow",
+  kind: "wish",
+  title: "Use this system to help my day job tomorrow morning",
+  status: "unspecified",
+  claimKind: "wish",
+  claimStatus: "unexamined",
+  tags: ["work", "tomorrow"],
+  deps: [],
+  evaluation: {
+    reproLevel: "manual-human",
+    manual: {
+      timeBudgetMinutes: 5,
+      difficulty: "easy",
+      steps: [
+        {
+          description: "At the end of the morning, list tasks done and note whether any were directly helped by WRP.",
+          expected: "At least one real task is helped by this system."
+        }
+      ]
+    }
+  },
+  body: "Freeform notes about how this wish should work."
+})
+
+const kebabCase = (input: string) =>
+  input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "")
+
+const randomSuffix = Effect.gen(function*() {
+  const n = yield* Random.nextInt
+  const normalized = Math.abs(n % 1679616)
+  return normalized.toString(36).padStart(4, "0")
+})
+
+const ensureLayout = (rootDir: string, config: WrpConfig) =>
+  Effect.gen(function*() {
+    const created: string[] = []
+    const promptgraphRoot = path.join(rootDir, config.promptgraphDir)
+    const targetsRoot = path.join(rootDir, config.targetsDir)
+
+    const requiredDirs = [
+      promptgraphRoot,
+      path.join(promptgraphRoot, "nodes"),
+      path.join(promptgraphRoot, "nodes", "wishes"),
+      path.join(promptgraphRoot, "nodes", "prompts"),
+      path.join(promptgraphRoot, "nodes", "observations"),
+      path.join(promptgraphRoot, "nodes", "decisions"),
+      path.join(promptgraphRoot, "nodes", "external"),
+      path.join(promptgraphRoot, "generated"),
+      path.join(promptgraphRoot, "generated", "specs"),
+      path.join(promptgraphRoot, "generated", "notes"),
+      path.join(promptgraphRoot, "runs"),
+      targetsRoot
+    ]
+
+    for (const dir of requiredDirs) {
+      const exists = yield* fileExists(dir)
+      if (!exists) {
+        yield* ensureDir(dir)
+        created.push(dir)
+      }
+    }
+
+    const reposPath = path.join(targetsRoot, "repos.yaml")
+    const reposExists = yield* fileExists(reposPath)
+    if (!reposExists) {
+      yield* writeFile(reposPath, "repos: []\n")
+      created.push(reposPath)
+    }
+
+    return created
+  })
+
+const wishesExist = (rootDir: string, config: WrpConfig) =>
+  Effect.gen(function*() {
+    const wishesDir = path.join(rootDir, config.promptgraphDir, "nodes", "wishes")
+    const exists = yield* fileExists(wishesDir)
+    if (!exists) {
+      return false
+    }
+
+    const entries = yield* Effect.tryPromise({
+      try: () => fs.readdir(wishesDir),
+      catch: (error) => error as Error
+    })
+
+    return entries.some((entry) => entry.endsWith(".md"))
+  })
+
+export const initWorkspace = (rootDir: string) =>
+  Effect.gen(function*() {
+    const configPath = path.join(rootDir, "wrp.config.json")
+    const configExists = yield* fileExists(configPath)
+    const config = configExists ? yield* loadConfig(rootDir) : defaultConfig
+
+    const created = yield* ensureLayout(rootDir, config)
+
+    if (!configExists) {
+      yield* writeDefaultConfig(rootDir, config)
+      created.push(configPath)
+    }
+
+    const hasWishes = yield* wishesExist(rootDir, config)
+    let initialWishPath: string | undefined
+    if (!hasWishes) {
+      const wish = rootWish()
+      yield* writeNode(rootDir, config.promptgraphDir, wish)
+      initialWishPath = nodeFilePath(rootDir, config.promptgraphDir, wish)
+      created.push(initialWishPath)
+    }
+
+    return { created, initialWishPath }
+  })
+
+export const addWish = (
+  rootDir: string,
+  title: string,
+  tags: Array<string> = []
+) =>
+  Effect.gen(function*() {
+    const config = yield* loadConfig(rootDir)
+    const suffix = yield* randomSuffix
+    const slug = kebabCase(title) || "wish"
+    const id = `w-${slug}-${suffix}`
+
+    const wish: WishNode = {
+      id,
+      kind: "wish",
+      title,
+      status: "unspecified",
+      claimKind: "wish",
+      claimStatus: "unexamined",
+      tags: tags.length > 0 ? tags : undefined,
+      deps: [],
+      evaluation: defaultManualEvaluation
+    }
+
+    yield* writeNode(rootDir, config.promptgraphDir, wish)
+    const filePath = nodeFilePath(rootDir, config.promptgraphDir, wish)
+
+    return { wish, filePath }
+  })
+
+export const listNodes = (
+  rootDir: string,
+  filters: { kind?: string; tag?: string; status?: string }
+) =>
+  Effect.gen(function*() {
+    const config = yield* loadConfig(rootDir)
+    const nodes = yield* loadAllNodes(rootDir, config.promptgraphDir)
+    const filtered = nodes.filter((node) => {
+      if (filters.kind && node.kind !== filters.kind) {
+        return false
+      }
+      if (filters.tag && !(node.tags ?? []).includes(filters.tag)) {
+        return false
+      }
+      if (filters.status && node.kind === "wish") {
+        return (node as WishNode).status === filters.status
+      }
+      if (filters.status && node.kind !== "wish") {
+        return false
+      }
+      return true
+    })
+
+    return filtered
+  })
+
+export const findNode = (
+  rootDir: string,
+  id: string
+) =>
+  Effect.gen(function*() {
+    const config = yield* loadConfig(rootDir)
+    const node = yield* readNodeById(rootDir, config.promptgraphDir, id)
+    return node
+  })
+
+export const updateClaimStatus = (
+  rootDir: string,
+  node: AnyNode,
+  status: ClaimStatus
+) =>
+  Effect.gen(function*() {
+    const config = yield* loadConfig(rootDir)
+    const updated: AnyNode = { ...node, claimStatus: status }
+    yield* writeNode(rootDir, config.promptgraphDir, updated)
+    return updated
+  })
+
+const logRun = (
+  rootDir: string,
+  config: WrpConfig,
+  entry: string
+) =>
+  Effect.gen(function*() {
+    const runsDir = path.join(rootDir, config.promptgraphDir, "runs")
+    yield* ensureDir(runsDir)
+    const now = new Date()
+    const dateStamp = now.toISOString().slice(0, 10)
+    const logPath = path.join(runsDir, `${dateStamp}.log`)
+    const line = `${now.toISOString()} ${entry}\n`
+    yield* Effect.tryPromise({
+      try: () => fs.appendFile(logPath, line, "utf8"),
+      catch: (error) => error as Error
+    })
+    return logPath
+  })
+
+export const evaluateManual = (
+  rootDir: string,
+  node: AnyNode,
+  decision: "y" | "n" | "i"
+) =>
+  Effect.gen(function*() {
+    const config = yield* loadConfig(rootDir)
+    const previous = node.claimStatus ?? "unexamined"
+    const claimStatus: ClaimStatus = decision === "y"
+      ? "supported"
+      : decision === "n"
+      ? "falsified"
+      : "inconclusive"
+
+    const updated = { ...node, claimStatus }
+    yield* writeNode(rootDir, config.promptgraphDir, updated)
+    const logPath = yield* logRun(
+      rootDir,
+      config,
+      `${node.id} ${previous} -> ${claimStatus}`
+    )
+
+    return { updated, logPath }
+  })
+
+export const formatNodeSummary = (node: AnyNode): string => {
+  const parts = [
+    node.id.padEnd(26, " "),
+    node.kind.padEnd(6, " "),
+    node.kind === "wish" ? (node as WishNode).status.padEnd(12, " ") : "".padEnd(12, " "),
+    (node.tags ?? []).join(",")
+  ]
+
+  return parts.join(" ")
+}
+
+export const printTable = (nodes: Array<AnyNode>) =>
+  Effect.gen(function*() {
+    yield* Console.log("id                          kind   status        tags")
+    for (const node of nodes) {
+      yield* Console.log(formatNodeSummary(node))
+    }
+  })

--- a/packages-native/wrp/src/editor.ts
+++ b/packages-native/wrp/src/editor.ts
@@ -1,0 +1,15 @@
+import { spawn } from "node:child_process"
+import * as Effect from "effect/Effect"
+
+export const openInEditor = (editor: string, filePath: string) =>
+  Effect.async<void, Error>((resume) => {
+    const child = spawn(editor, [filePath], { stdio: "inherit" })
+    child.on("error", (error) => resume(Effect.fail(error)))
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resume(Effect.succeed(undefined))
+      } else {
+        resume(Effect.fail(new Error(`Editor exited with code ${code}`)))
+      }
+    })
+  })

--- a/packages-native/wrp/src/fsNodes.ts
+++ b/packages-native/wrp/src/fsNodes.ts
@@ -1,0 +1,157 @@
+import { promises as fs } from "node:fs"
+import path from "node:path"
+import * as Effect from "effect/Effect"
+import YAML from "yaml"
+import { type AnyNode, type NodeKind } from "./model.js"
+
+const boundaryPattern = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/
+
+const kindDirectory = (kind: NodeKind): string => {
+  switch (kind) {
+    case "wish":
+      return "wishes"
+    case "prompt":
+      return "prompts"
+    case "observation":
+      return "observations"
+    case "decision":
+      return "decisions"
+    default:
+      return "external"
+  }
+}
+
+const parseMarkdown = (content: string): { frontmatter: Record<string, unknown>; body: string } => {
+  const match = boundaryPattern.exec(content)
+
+  if (!match) {
+    return { frontmatter: {}, body: content.trimEnd() }
+  }
+
+  const [, frontmatterText, body] = match
+  const parsed = YAML.parse(frontmatterText) as Record<string, unknown> | null
+
+  return { frontmatter: parsed ?? {}, body: body.trimStart() }
+}
+
+const serializeMarkdown = (frontmatter: Record<string, unknown>, body: string): string => {
+  const yaml = YAML.stringify(frontmatter, { lineWidth: 120 }).trimEnd()
+  const normalizedBody = body.trimEnd()
+
+  if (normalizedBody.length === 0) {
+    return `---\n${yaml}\n---\n`
+  }
+
+  return `---\n${yaml}\n---\n\n${normalizedBody}\n`
+}
+
+const nodePath = (rootDir: string, promptgraphDir: string, kind: NodeKind, id: string) =>
+  path.join(rootDir, promptgraphDir, "nodes", kindDirectory(kind), `${id}.md`)
+
+const readFileEffect = (filePath: string) =>
+  Effect.tryPromise({
+    try: () => fs.readFile(filePath, "utf8"),
+    catch: (error) => error as Error
+  })
+
+const writeFileEffect = (filePath: string, content: string) =>
+  Effect.tryPromise({
+    try: () => fs.writeFile(filePath, content, "utf8"),
+    catch: (error) => error as Error
+  })
+
+const ensureDir = (dir: string) =>
+  Effect.tryPromise({
+    try: () => fs.mkdir(dir, { recursive: true }),
+    catch: (error) => error as Error
+  })
+
+const walkMarkdownFiles = (
+  directory: string
+): Effect.Effect<Array<string>, Error> =>
+  Effect.gen(function*() {
+    const exists = yield* Effect.tryPromise({
+      try: () => fs.access(directory).then(() => true).catch(() => false),
+      catch: (error) => error as Error
+    })
+
+    if (!exists) {
+      return []
+    }
+
+    const entries = yield* Effect.tryPromise({
+      try: () => fs.readdir(directory, { withFileTypes: true }),
+      catch: (error) => error as Error
+    })
+
+    const files: Array<string> = []
+
+    for (const entry of entries) {
+      const fullPath = path.join(directory, entry.name)
+      if (entry.isDirectory()) {
+        const nested = yield* walkMarkdownFiles(fullPath)
+        files.push(...nested)
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        files.push(fullPath)
+      }
+    }
+
+    return files
+  })
+
+export const parseNodeFile = (content: string): AnyNode => {
+  const { frontmatter, body } = parseMarkdown(content)
+  const node: AnyNode = {
+    ...(frontmatter as AnyNode),
+    body
+  }
+  return node
+}
+
+export const serializeNodeFile = (node: AnyNode): string => {
+  const { body = "", ...rest } = node
+  return serializeMarkdown(rest, body)
+}
+
+export const loadAllNodes = (
+  rootDir: string,
+  promptgraphDir: string
+): Effect.Effect<Array<AnyNode>> =>
+  Effect.gen(function*() {
+    const nodesDir = path.join(rootDir, promptgraphDir, "nodes")
+    const files = yield* walkMarkdownFiles(nodesDir)
+    const parsed: Array<AnyNode> = []
+
+    for (const file of files) {
+      const content = yield* readFileEffect(file)
+      parsed.push(parseNodeFile(content))
+    }
+
+    return parsed
+  })
+
+export const writeNode = (
+  rootDir: string,
+  promptgraphDir: string,
+  node: AnyNode
+): Effect.Effect<void> =>
+  Effect.gen(function*() {
+    const filePath = nodePath(rootDir, promptgraphDir, node.kind, node.id)
+    const dir = path.dirname(filePath)
+    yield* ensureDir(dir)
+    const content = serializeNodeFile(node)
+    yield* writeFileEffect(filePath, content)
+  })
+
+export const readNodeById = (
+  rootDir: string,
+  promptgraphDir: string,
+  id: string
+): Effect.Effect<AnyNode | undefined> =>
+  Effect.gen(function*() {
+    const nodes = yield* loadAllNodes(rootDir, promptgraphDir)
+    return nodes.find((node) => node.id === id)
+  })
+
+export const nodeFilePath = (rootDir: string, promptgraphDir: string, node: AnyNode) =>
+  nodePath(rootDir, promptgraphDir, node.kind, node.id)

--- a/packages-native/wrp/src/index.ts
+++ b/packages-native/wrp/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./cli.js"
+export * from "./config.js"
+export * from "./core.js"
+export * from "./fsNodes.js"
+export * from "./model.js"
+export * from "./targets.js"

--- a/packages-native/wrp/src/interactive.ts
+++ b/packages-native/wrp/src/interactive.ts
@@ -1,0 +1,45 @@
+import { createInterface } from "node:readline/promises"
+import { stdin, stdout } from "node:process"
+import * as Console from "effect/Console"
+import * as Effect from "effect/Effect"
+import YAML from "yaml"
+import { type AnyNode } from "./model.js"
+
+export const runInputPrompt = (message: string) =>
+  Effect.tryPromise({
+    try: async () => {
+      const rl = createInterface({ input: stdin, output: stdout })
+      const answer = await rl.question(`${message} `)
+      rl.close()
+      return answer
+    },
+    catch: (error) => error as Error
+  })
+
+export const runEvaluationPrompt = (node: AnyNode) =>
+  Effect.gen(function*() {
+    const evaluation = node.evaluation
+    if (!evaluation || evaluation.reproLevel !== "manual-human") {
+      return
+    }
+    yield* Console.log(`Evaluation for ${node.id}`)
+    yield* Console.log(`Time budget: ${evaluation.manual.timeBudgetMinutes} minutes`)
+    yield* Console.log(`Difficulty: ${evaluation.manual.difficulty}`)
+    let index = 1
+    for (const step of evaluation.manual.steps) {
+      yield* Console.log(`${index}. ${step.description}`)
+      yield* Console.log(`   Expected: ${step.expected}`)
+      index += 1
+    }
+  })
+
+export const showNodeDetails = (node: AnyNode) =>
+  Effect.gen(function*() {
+    const { body = "", ...frontmatter } = node
+    const yaml = YAML.stringify(frontmatter, { lineWidth: 120 }).trimEnd()
+    yield* Console.log(`---\n${yaml}\n---`)
+    if (body.trim().length > 0) {
+      yield* Console.log("")
+      yield* Console.log(body)
+    }
+  })

--- a/packages-native/wrp/src/model.ts
+++ b/packages-native/wrp/src/model.ts
@@ -1,0 +1,60 @@
+export type NodeKind =
+  | "wish"
+  | "prompt"
+  | "observation"
+  | "decision"
+
+export type ClaimStatus =
+  | "unexamined"
+  | "underTest"
+  | "supported"
+  | "falsified"
+  | "inconclusive"
+
+export type WishStatus =
+  | "unspecified"
+  | "inProgress"
+  | "fulfilled"
+  | "blocked"
+
+export type EvaluationManualStep = {
+  description: string
+  expected: string
+}
+
+export type EvaluationManual = {
+  timeBudgetMinutes: number
+  difficulty: "easy" | "medium" | "hard"
+  steps: EvaluationManualStep[]
+}
+
+export type EvaluationSpec = {
+  reproLevel: "manual-human"
+  manual: EvaluationManual
+  script?: unknown
+  metric?: unknown
+}
+
+export type BaseNode = {
+  id: string
+  kind: NodeKind
+  title: string
+  deps?: string[]
+  tags?: string[]
+  body?: string
+  [key: string]: unknown
+}
+
+export type ClaimOverlay = {
+  claimKind?: "wish" | "decision" | "observation"
+  claimStatus?: ClaimStatus
+  evaluation?: EvaluationSpec
+}
+
+export type WishNode = BaseNode &
+  ClaimOverlay & {
+    kind: "wish"
+    status: WishStatus
+  }
+
+export type AnyNode = WishNode | BaseNode

--- a/packages-native/wrp/src/targets.ts
+++ b/packages-native/wrp/src/targets.ts
@@ -1,0 +1,46 @@
+import { promises as fs } from "node:fs"
+import path from "node:path"
+import * as Effect from "effect/Effect"
+import YAML from "yaml"
+import { type WrpConfig } from "./config.js"
+
+export type TargetRepoConfig = {
+  id: string
+  remote: string
+  localRoot: string
+  defaultBranch: string
+}
+
+export type TargetsConfig = {
+  repos: TargetRepoConfig[]
+}
+
+export const loadTargets = (
+  rootDir: string,
+  config: WrpConfig
+): Effect.Effect<TargetsConfig> =>
+  Effect.gen(function*() {
+    const targetsDir = path.join(rootDir, config.targetsDir)
+    const reposPath = path.join(targetsDir, "repos.yaml")
+
+    const exists = yield* Effect.tryPromise({
+      try: () => fs.access(reposPath).then(() => true).catch(() => false),
+      catch: (error) => error as Error
+    })
+
+    if (!exists) {
+      return { repos: [] }
+    }
+
+    const content = yield* Effect.tryPromise({
+      try: () => fs.readFile(reposPath, "utf8"),
+      catch: (error) => error as Error
+    })
+
+    const parsed = YAML.parse(content) as TargetsConfig | null
+    if (!parsed || !Array.isArray(parsed.repos)) {
+      return { repos: [] }
+    }
+
+    return { repos: parsed.repos }
+  })

--- a/packages-native/wrp/test/wrp.test.ts
+++ b/packages-native/wrp/test/wrp.test.ts
@@ -1,0 +1,48 @@
+import { assert, describe, it } from "@effect/vitest"
+import { promises as fs } from "node:fs"
+import path from "node:path"
+import { tmpdir } from "node:os"
+import * as Effect from "effect/Effect"
+import { addWish, evaluateManual, initWorkspace, listNodes } from "../src/core.js"
+import { loadConfig } from "../src/config.js"
+import { readNodeById } from "../src/fsNodes.js"
+
+const makeTempDir = () =>
+  Effect.tryPromise({
+    try: () => fs.mkdtemp(path.join(tmpdir(), "wrp-")),
+    catch: (error) => error as Error
+  })
+
+describe("wrp cli core", () => {
+  it.effect("creates wishes and lists them by tag", () =>
+    Effect.gen(function*() {
+      const dir = yield* makeTempDir()
+      yield* initWorkspace(dir)
+      yield* addWish(dir, "Review PR 123", ["work", "tomorrow"])
+
+      const wishes = yield* listNodes(dir, { kind: "wish", tag: "tomorrow" })
+      const ids = wishes.map((wish) => wish.id)
+
+      assert.ok(ids.some((id) => id === "w-use-system-tomorrow"))
+      assert.ok(ids.some((id) => id.includes("review-pr-123")))
+    }))
+
+  it.effect("manual evaluation updates claim status and logs", () =>
+    Effect.gen(function*() {
+      const dir = yield* makeTempDir()
+      const { promptgraphDir } = yield* loadConfig(dir)
+      yield* initWorkspace(dir)
+      const node = yield* readNodeById(dir, promptgraphDir, "w-use-system-tomorrow")
+      assert.exists(node)
+
+      const result = yield* evaluateManual(dir, node!, "y")
+      assert.strictEqual(result.updated.claimStatus, "supported")
+
+      const logContent = yield* Effect.tryPromise({
+        try: () => fs.readFile(result.logPath, "utf8"),
+        catch: (error) => error as Error
+      })
+
+      assert.match(logContent, /w-use-system-tomorrow unexamined -> supported/)
+    }))
+})

--- a/packages-native/wrp/tsconfig.build.json
+++ b/packages-native/wrp/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "bin/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {
+    "outDir": "build/esm",
+    "declarationDir": "build/dts",
+    "rootDir": "."
+  },
+  "references": []
+}

--- a/packages-native/wrp/tsconfig.json
+++ b/packages-native/wrp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [],
+  "references": [
+    { "path": "tsconfig.src.json" },
+    { "path": "tsconfig.test.json" }
+  ]
+}

--- a/packages-native/wrp/tsconfig.src.json
+++ b/packages-native/wrp/tsconfig.src.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "bin"],
+  "references": [
+    { "path": "../patterns/tsconfig.src.json" },
+    { "path": "../debug/tsconfig.src.json" }
+  ],
+  "compilerOptions": {
+    "outDir": "build/src",
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "rootDir": "."
+  }
+}

--- a/packages-native/wrp/tsconfig.test.json
+++ b/packages-native/wrp/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["test"],
+  "references": [
+    { "path": "tsconfig.src.json" },
+    { "path": "../vitest/tsconfig.src.json" }
+  ],
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
+    "rootDir": "test",
+    "noEmit": true
+  }
+}

--- a/packages-native/wrp/vitest.config.ts
+++ b/packages-native/wrp/vitest.config.ts
@@ -1,0 +1,6 @@
+import { mergeConfig, type ViteUserConfig } from "vitest/config"
+import shared from "../../vitest.shared.ts"
+
+const config: ViteUserConfig = {}
+
+export default mergeConfig(shared, config)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@edge-runtime/vm':
         specifier: ^5.0.0
         version: 5.0.0
+      '@effect-native/wrp':
+        specifier: workspace:*
+        version: link:packages-native/wrp
       '@effect/build-utils':
         specifier: ^0.8.9
         version: 0.8.9
@@ -64,7 +67,7 @@ importers:
         version: 0.23.5
       '@effect/vitest':
         specifier: latest
-        version: 0.26.0(effect@3.18.4)(vitest@3.2.4)
+        version: 0.26.0(effect@3.19.5)(vitest@3.2.4)
       '@eslint/compat':
         specifier: ^1.3.2
         version: 1.4.0(eslint@9.37.0)
@@ -238,22 +241,6 @@ importers:
         version: 8.18.3
     publishDirectory: dist
 
-  packages-native/debug-demos:
-    dependencies:
-      effect:
-        specifier: latest
-        version: 3.18.4
-    devDependencies:
-      '@types/node':
-        specifier: ^22.0.0
-        version: 22.18.8
-      tsx:
-        specifier: ^4.19.0
-        version: 4.20.6
-      typescript:
-        specifier: ^5.6.0
-        version: 5.9.3
-
   packages-native/effect-native:
     dependencies:
       '@effect/cli':
@@ -293,6 +280,32 @@ importers:
       '@effect/vitest':
         specifier: latest
         version: 0.26.0(effect@3.18.4)(vitest@3.2.4)
+    publishDirectory: dist
+
+  packages-native/wrp:
+    dependencies:
+      '@effect/cli':
+        specifier: ^0.71.0
+        version: 0.71.0(@effect/platform@0.91.1(effect@3.19.5))(@effect/printer-ansi@0.46.0(@effect/typeclass@0.37.0(effect@3.19.5))(effect@3.19.5))(@effect/printer@0.46.0(@effect/typeclass@0.37.0(effect@3.19.5))(effect@3.19.5))(effect@3.19.5)
+      '@effect/platform':
+        specifier: ^0.91.1
+        version: 0.91.1(effect@3.19.5)
+      '@effect/platform-node':
+        specifier: ^0.97.1
+        version: 0.97.1(@effect/cluster@0.50.4(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5)
+      effect:
+        specifier: latest
+        version: 3.19.5
+      tsx:
+        specifier: ^4.20.5
+        version: 4.20.6
+      yaml:
+        specifier: ^2.5.1
+        version: 2.8.1
+    devDependencies:
+      '@effect/vitest':
+        specifier: latest
+        version: 0.27.0(effect@3.19.5)(vitest@3.2.4)
     publishDirectory: dist
 
   scratchpad:
@@ -1273,6 +1286,12 @@ packages:
     resolution: {integrity: sha512-h7r21XRtHpl8CQmIuplCK54bYJkUij4c6bUxK27y4d9dTXn4s7c/I3Lilb4VZxv3P3S3sChCu5YIGW4pdQFjZg==}
     peerDependencies:
       effect: ^3.18.0
+      vitest: ^3.2.0
+
+  '@effect/vitest@0.27.0':
+    resolution: {integrity: sha512-8bM7n9xlMUYw9GqPIVgXFwFm2jf27m/R7psI64PGpwU5+26iwyxp9eAXEsfT5S6lqztYfpQQ1Ubp5o6HfNYzJQ==}
+    peerDependencies:
+      effect: ^3.19.0
       vitest: ^3.2.0
 
   '@effect/wa-sqlite@0.1.2':
@@ -3141,6 +3160,9 @@ packages:
 
   effect@3.18.4:
     resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
+
+  effect@3.19.5:
+    resolution: {integrity: sha512-P/Yml/wuqfIWVg4EH3QWKEqe4txwZVa9tCnlp24mRtIxN/wbn27KLOuDyF0HcKuMYsX/SGw8Lxe0T0Y6q4tvBA==}
 
   electron-to-chromium@1.5.233:
     resolution: {integrity: sha512-iUdTQSf7EFXsDdQsp8MwJz5SVk4APEFqXU/S47OtQ0YLqacSwPXdZ5vRlMX3neb07Cy2vgioNuRnWUXFwuslkg==}
@@ -6679,6 +6701,16 @@ snapshots:
       toml: 3.0.0
       yaml: 2.8.1
 
+  '@effect/cli@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(@effect/printer-ansi@0.46.0(@effect/typeclass@0.37.0(effect@3.19.5))(effect@3.19.5))(@effect/printer@0.46.0(@effect/typeclass@0.37.0(effect@3.19.5))(effect@3.19.5))(effect@3.19.5)':
+    dependencies:
+      '@effect/platform': 0.91.1(effect@3.19.5)
+      '@effect/printer': 0.46.0(@effect/typeclass@0.37.0(effect@3.19.5))(effect@3.19.5)
+      '@effect/printer-ansi': 0.46.0(@effect/typeclass@0.37.0(effect@3.19.5))(effect@3.19.5)
+      effect: 3.19.5
+      ini: 4.1.3
+      toml: 3.0.0
+      yaml: 2.8.1
+
   '@effect/cli@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(@effect/printer-ansi@0.46.0(@effect/typeclass@0.37.0(effect@3.18.4))(effect@3.18.4))(@effect/printer@0.46.0(@effect/typeclass@0.37.0(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)':
     dependencies:
       '@effect/platform': 0.92.1(effect@3.18.4)
@@ -6704,6 +6736,14 @@ snapshots:
       '@effect/sql': 0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.91.1(effect@3.18.4))(effect@3.18.4)
       '@effect/workflow': 0.11.3(@effect/platform@0.91.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)
       effect: 3.18.4
+
+  '@effect/cluster@0.50.4(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5))(effect@3.19.5)':
+    dependencies:
+      '@effect/platform': 0.91.1(effect@3.19.5)
+      '@effect/rpc': 0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5)
+      '@effect/sql': 0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5)
+      '@effect/workflow': 0.11.3(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5)
+      effect: 3.19.5
 
   '@effect/cluster@0.50.4(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)':
     dependencies:
@@ -6738,6 +6778,12 @@ snapshots:
     dependencies:
       '@effect/platform': 0.91.1(effect@3.18.4)
       effect: 3.18.4
+      uuid: 11.1.0
+
+  '@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5)':
+    dependencies:
+      '@effect/platform': 0.91.1(effect@3.19.5)
+      effect: 3.19.5
       uuid: 11.1.0
 
   '@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)':
@@ -6830,6 +6876,20 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@effect/platform-node-shared@0.50.1(@effect/cluster@0.50.4(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5)':
+    dependencies:
+      '@effect/cluster': 0.50.4(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5))(effect@3.19.5)
+      '@effect/platform': 0.91.1(effect@3.19.5)
+      '@effect/rpc': 0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5)
+      '@effect/sql': 0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5)
+      '@parcel/watcher': 2.5.1
+      effect: 3.19.5
+      multipasta: 0.2.7
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@effect/platform-node-shared@0.51.4(@effect/cluster@0.50.4(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)':
     dependencies:
       '@effect/cluster': 0.50.4(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)
@@ -6889,6 +6949,21 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@effect/platform-node@0.97.1(@effect/cluster@0.50.4(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5)':
+    dependencies:
+      '@effect/cluster': 0.50.4(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5))(effect@3.19.5)
+      '@effect/platform': 0.91.1(effect@3.19.5)
+      '@effect/platform-node-shared': 0.50.1(@effect/cluster@0.50.4(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5)
+      '@effect/rpc': 0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5)
+      '@effect/sql': 0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5)
+      effect: 3.19.5
+      mime: 3.0.0
+      undici: 7.16.0
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@effect/platform-node@0.98.3(@effect/cluster@0.50.4(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)':
     dependencies:
       '@effect/cluster': 0.50.4(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)
@@ -6918,6 +6993,13 @@ snapshots:
       msgpackr: 1.11.5
       multipasta: 0.2.7
 
+  '@effect/platform@0.91.1(effect@3.19.5)':
+    dependencies:
+      effect: 3.19.5
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.11.5
+      multipasta: 0.2.7
+
   '@effect/platform@0.92.1(effect@3.18.4)':
     dependencies:
       effect: 3.18.4
@@ -6931,10 +7013,21 @@ snapshots:
       '@effect/typeclass': 0.37.0(effect@3.18.4)
       effect: 3.18.4
 
+  '@effect/printer-ansi@0.46.0(@effect/typeclass@0.37.0(effect@3.19.5))(effect@3.19.5)':
+    dependencies:
+      '@effect/printer': 0.46.0(@effect/typeclass@0.37.0(effect@3.19.5))(effect@3.19.5)
+      '@effect/typeclass': 0.37.0(effect@3.19.5)
+      effect: 3.19.5
+
   '@effect/printer@0.46.0(@effect/typeclass@0.37.0(effect@3.18.4))(effect@3.18.4)':
     dependencies:
       '@effect/typeclass': 0.37.0(effect@3.18.4)
       effect: 3.18.4
+
+  '@effect/printer@0.46.0(@effect/typeclass@0.37.0(effect@3.19.5))(effect@3.19.5)':
+    dependencies:
+      '@effect/typeclass': 0.37.0(effect@3.19.5)
+      effect: 3.19.5
 
   '@effect/rpc@0.71.0(@effect/platform@0.90.10(effect@3.18.4))(effect@3.18.4)':
     dependencies:
@@ -6946,6 +7039,12 @@ snapshots:
     dependencies:
       '@effect/platform': 0.91.1(effect@3.18.4)
       effect: 3.18.4
+      msgpackr: 1.11.5
+
+  '@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5)':
+    dependencies:
+      '@effect/platform': 0.91.1(effect@3.19.5)
+      effect: 3.19.5
       msgpackr: 1.11.5
 
   '@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)':
@@ -7086,6 +7185,13 @@ snapshots:
       effect: 3.18.4
       uuid: 11.1.0
 
+  '@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5)':
+    dependencies:
+      '@effect/experimental': 0.56.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5)
+      '@effect/platform': 0.91.1(effect@3.19.5)
+      effect: 3.19.5
+      uuid: 11.1.0
+
   '@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)':
     dependencies:
       '@effect/experimental': 0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)
@@ -7097,6 +7203,10 @@ snapshots:
     dependencies:
       effect: 3.18.4
 
+  '@effect/typeclass@0.37.0(effect@3.19.5)':
+    dependencies:
+      effect: 3.19.5
+
   '@effect/vitest@0.25.1(effect@3.18.4)(vitest@3.2.4)':
     dependencies:
       effect: 3.18.4
@@ -7105,6 +7215,16 @@ snapshots:
   '@effect/vitest@0.26.0(effect@3.18.4)(vitest@3.2.4)':
     dependencies:
       effect: 3.18.4
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.18.8)(@vitest/browser@3.2.4)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+
+  '@effect/vitest@0.26.0(effect@3.19.5)(vitest@3.2.4)':
+    dependencies:
+      effect: 3.19.5
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.18.8)(@vitest/browser@3.2.4)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+
+  '@effect/vitest@0.27.0(effect@3.19.5)(vitest@3.2.4)':
+    dependencies:
+      effect: 3.19.5
       vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.18.8)(@vitest/browser@3.2.4)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@effect/wa-sqlite@0.1.2': {}
@@ -7120,6 +7240,12 @@ snapshots:
       '@effect/platform': 0.91.1(effect@3.18.4)
       '@effect/rpc': 0.71.0(@effect/platform@0.91.1(effect@3.18.4))(effect@3.18.4)
       effect: 3.18.4
+
+  '@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.5))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5))(effect@3.19.5)':
+    dependencies:
+      '@effect/platform': 0.91.1(effect@3.19.5)
+      '@effect/rpc': 0.71.0(@effect/platform@0.91.1(effect@3.19.5))(effect@3.19.5)
+      effect: 3.19.5
 
   '@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)':
     dependencies:
@@ -8944,6 +9070,11 @@ snapshots:
   ee-first@1.1.1: {}
 
   effect@3.18.4:
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      fast-check: 3.23.2
+
+  effect@3.19.5:
     dependencies:
       '@standard-schema/spec': 1.0.0
       fast-check: 3.23.2


### PR DESCRIPTION
## Summary
- add new @effect-native/wrp package with CLI commands for init/add/list/show/eval/repo list
- implement markdown-backed node parsing, workspace initialization, and targets loader
- cover core workflows with vitest smoke tests

## Testing
- nix develop --command pnpm -C packages-native/wrp test -- --run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e92c33d14832f92801806c8b07b3a)