### PR TITLE
Implement OIDC authentication and provenance for npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,27 @@ jobs:
       - name: Install dependencies
         uses: effect-native/effect-native/.github/actions/setup@6dbea705cc0cbb0aad92e60785a8179bd8555434
 
-      - name: Create Release Pull Request or Publish
+      - name: Setup Node for npm Registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: "23.7.0"
+          registry-url: "https://registry.npmjs.org"
+          scope: "@effect-native"
+          cache: pnpm
+
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
+      - name: Create Release Pull Request
+        id: changesets
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba
         with:
           version: pnpm changeset-version
-          publish: pnpm changeset-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish with OIDC
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: pnpm changeset-publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,3 +150,31 @@ This project uses Nix for dependency management and reproducible builds. All dev
   - Then re-run tests: `nix develop --command pnpm test`
 
 In practice: relying on `nix develop` 100% of the time avoids ABI mismatches and “everything just works.”
+
+## Git and GitHub Workflow
+
+### Repository Context
+
+This is the `effect-native/effect-native` repository - a fork of `Effect-TS/effect` with additional native packages and tooling.
+
+- **origin**: `https://github.com/effect-native/effect-native.git` (our fork)
+- **upstream**: `https://github.com/Effect-TS/effect.git` (upstream Effect-TS)
+
+### Pull Request Defaults
+
+**When creating pull requests, ALWAYS target the `effect-native/effect-native` repository by default:**
+
+```bash
+# ✅ Correct - PR to our fork
+gh pr create --repo effect-native/effect-native --base effect-native/main --head feature-branch
+
+# ❌ Wrong - PR to upstream (only do this when explicitly asked)
+gh pr create # defaults to upstream when in a fork
+```
+
+**Rationale:**
+- Most development happens in our fork
+- PRs to upstream require explicit intent and coordination
+- Accidentally creating PRs to upstream creates noise and confusion
+
+**Exception:** Only create PRs to upstream `Effect-TS/effect` when explicitly asked to contribute changes upstream.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "docgen": "pnpm --recursive --filter \"./packages-native/**/*\" --filter \"!./packages-native/*-demos\" exec docgen && node scripts/docs.mjs",
     "test-types": "tstyche",
     "changeset-version": "changeset version && node scripts/version.mjs && node scripts/force-libsqlite-embedded.mjs",
-    "changeset-publish": "pnpm codemod && pnpm build && TEST_DIST= pnpm vitest && changeset publish && node scripts/postpublish-dist-tags.mjs"
+    "changeset-publish": "pnpm codemod && pnpm build && TEST_DIST= pnpm vitest && changeset publish --provenance && node scripts/postpublish-dist-tags.mjs"
   },
   "resolutions": {
     "effect": "latest",


### PR DESCRIPTION
## Summary

- Replaces static NPM_TOKEN authentication with GitHub OIDC for enhanced security and short-lived credentials
- Adds package provenance attestations to improve supply chain transparency and verification

## Changes

- Split changesets action into separate version and publish steps
- Configure OIDC token authentication using GitHub's identity provider
- Add `--provenance` flag to enable package attestations
- Conditional publish only when no pending changesets remain
- Upgrade npm to latest version for OIDC support

## Security Benefits

- Eliminates long-lived static tokens in favor of short-lived OIDC tokens
- Adds cryptographic provenance linking published packages to source commits
- Improves supply chain security and transparency for package consumers