### PR TITLE
feat: add note CLI and @effect-native/schemas packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,4 @@ jobs:
         run: pnpm changeset-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.specs/AGENTS.md
+++ b/.specs/AGENTS.md
@@ -1,0 +1,138 @@
+# Agent Instructions for Spec-Driven Development
+
+## 🚨 HIGHEST PRIORITY RULES 🚨
+
+### 1. The "Read-Only" Rule
+**NEVER** modify the codebase (src/test files) until **Phase 5 (Implementation)**.
+- Phases 1-4 are strictly for documentation and planning within the spec directory (e.g. `.specs/[feature-name]/` or `packages/[package-name]/SPEC/`).
+- Premature coding leads to technical debt and architectural misalignment.
+
+### 2. The "Authorization Gate" Protocol
+**NEVER** proceed to the next phase without explicit user approval.
+- **Stop** after completing a document.
+- **Present** the content to the user.
+- **Wait** for "Proceed" or "Approved".
+
+### 3. The "Single Source of Truth"
+The spec directory (e.g. `.specs/[feature-name]/` or `packages/[package-name]/SPEC/`) is the source of truth.
+- If the code contradicts the spec, the code is wrong (or the spec needs updating first).
+- Do not rely on conversation memory; rely on the written documents.
+
+### 4. The "Evidence-Based" Protocol
+**NEVER** conclude a task without experimental evidence.
+- All conclusions must be based on evidence that can be reliably reproduced by peer reviewers.
+- Do not simply state "it works" or "task complete." You must provide the test output, CLI logs, or verification results that prove the conclusion.
+
+---
+
+## 📋 The 5-Phase Workflow
+
+### Phase 1: Instructions (`instructions.md`)
+**Objective:** Capture the raw intent, context, and high-level goals.
+
+**✅ CONTENT:**
+- **Context:** Why are we doing this? What is the current state?
+- **User Story:** As a [role], I want [feature], so that [benefit].
+- **High-Level Goals:** Bullet points of desired outcomes.
+- **Out of Scope:** Explicitly state what we are NOT doing.
+
+**🛑 FORBIDDEN IN THIS PHASE:**
+- **Technical Jargon:** Avoid specific function names or file paths unless they are part of the problem description.
+- **Implementation Details:** Do not discuss *how* to build it.
+- **Atomic Requirements:** Do not write "The system shall..." statements yet.
+
+---
+
+### Phase 2: Requirements (`requirements.md`)
+**Objective:** Translate intent into atomic, testable, and unambiguous statements using **EARS Notation**.
+
+**✅ CONTENT:**
+- **Functional Requirements (FR):** What the system does.
+- **Non-Functional Requirements (NFR):** Performance, security, reliability.
+- **Constraints:** Tech stack limitations, legacy support.
+
+**📝 EARS NOTATION (Mandatory for FRs):**
+Use the **Easy Approach to Requirements Syntax** patterns. Format for readability - single line or multi-line are both fine:
+1.  **Ubiquitous (Always):** `The <System> shall <Response>`
+    *   *Ex: The Logger shall write all events to stdout.*
+2.  **Event-Driven (When):** `When <Trigger>, the <System> shall <Response>`
+    *   *Ex: When the user clicks Save, the System shall validate the input.*
+    *   *Also fine:* **When** the user clicks Save  
+        **Then** the System shall validate the input
+3.  **State-Driven (While):** `While <State>, the <System> shall <Response>`
+    *   *Ex: While the connection is lost, the Client shall queue outgoing requests.*
+4.  **Unwanted Behavior (If):** `If <Trigger>, the <System> shall <Response>`
+    *   *Ex: If the API returns a 500 error, the System shall retry twice.*
+5.  **Optional Feature (Where):** `Where <Feature is included>, the <System> shall <Response>`
+    *   *Ex: Where the Pro license is active, the System shall enable export.*
+
+**🛑 FORBIDDEN IN THIS PHASE:**
+- **Ambiguity:** Words like "fast", "easy", "user-friendly", "robust" (Use metrics instead: "under 200ms").
+- **Implementation Specifics:** Do not dictate *which* library or algorithm to use (that is Design).
+- **Pseudo-code:** No code blocks.
+
+---
+
+### Phase 3: Design (`design.md`)
+**Objective:** Define the technical architecture and implementation strategy.
+
+**✅ CONTENT:**
+- **Data Models:** Interfaces, Types, Database Schemas.
+- **API Signatures:** Function names, inputs, outputs.
+- **Module Architecture:** File structure, exports, dependencies.
+- **Algorithms:** Pseudo-code or logic flow for complex parts.
+- **Error Handling Strategy:** Specific error types and recovery flows.
+- **Test Strategy:** Unit vs. Integration, mocking strategies.
+
+**🛑 FORBIDDEN IN THIS PHASE:**
+- **Full Implementation:** Do not write the actual function bodies (use comments/pseudo-code).
+- **Vague Hand-waving:** Do not say "We will handle errors." Define *exactly* how.
+- **Scope Creep:** Do not add features not listed in `requirements.md`.
+
+---
+
+### Phase 4: Plan (`plan.md`)
+**Objective:** Create a step-by-step execution checklist.
+
+**✅ CONTENT:**
+- **Phased Execution:** Break work into logical chunks (e.g., "Setup", "Core Logic", "API Layer", "Tests").
+- **Atomic Tasks:** Each task should be a single commit or PR.
+- **Verification Steps:** For each task, define how to verify it (e.g., "Run `npm test`", "Check linter").
+- **Dependency Order:** Ensure Task B implies Task A is done.
+
+**🛑 FORBIDDEN IN THIS PHASE:**
+- **Time Estimates:** Do not estimate hours or days. Focus strictly on logical dependency and atomicity.
+- **Design Decisions:** If you are deciding *how* to do something here, go back to Phase 3.
+- **New Requirements:** If you find a missing requirement, go back to Phase 2.
+
+---
+
+### Phase 5: Implementation (Coding)
+**Objective:** Write code that satisfies the Design and passes the Requirements.
+
+**✅ CONTENT:**
+- **Code:** Writing source files.
+- **Tests:** Writing and running tests.
+- **Docs:** Updating JSDoc/Comments/README.
+
+**🚨 MANDATORY LOOP:**
+For every task in `plan.md`:
+1.  **Write Code** (matching `design.md`).
+2.  **Lint/Format** (Standard project linter).
+3.  **Compile/Check Types** (if applicable).
+4.  **Write/Run Tests** (Produce the experimental evidence).
+5.  **Commit**.
+
+**🛑 FORBIDDEN IN THIS PHASE:**
+- **Deviating from Design:** If the design proves impossible, **STOP**. Update `design.md` first, get approval, then continue.
+- **Skipping Verification:** Never tick a box in `plan.md` without running the verification step and showing the evidence.
+- **Leaving Broken Builds:** The codebase must compile and pass tests at the end of every step.
+
+---
+
+## 🛠️ General Repository Rules
+
+1.  **Linting:** Immediately run the project's linter/formatter after editing any file.
+2.  **Testing:** New features require new tests. Bug fixes require regression tests.
+3.  **Types:** If the language is typed (e.g., TypeScript, Go, Rust), strict type safety is required. No `any` or equivalent bypasses unless absolutely necessary and documented.
+4.  **Comments:** Code should be self-documenting. Use comments to explain *why*, not *what*.

--- a/.specs/AGENTS.md
+++ b/.specs/AGENTS.md
@@ -10,8 +10,10 @@
 ### 2. The "Authorization Gate" Protocol
 **NEVER** proceed to the next phase without explicit user approval.
 - **Stop** after completing a document.
+- **Commit** all phase artifacts to git before requesting approval.
 - **Present** the content to the user.
 - **Wait** for "Proceed" or "Approved".
+- **Commit** any refinements before moving to the next phase.
 
 ### 3. The "Single Source of Truth"
 The spec directory (e.g. `.specs/[feature-name]/` or `packages/[package-name]/SPEC/`) is the source of truth.
@@ -98,18 +100,29 @@ If it could be copy-pasted into a `.ts`, `.js`, or `.json` file and executed, it
 ---
 
 ### Phase 4: Plan (`plan.md`)
-**Objective:** Create a step-by-step execution checklist.
+**Objective:** Create a step-by-step execution checklist using **Red-Green-Refactor TDD**.
 
 **✅ CONTENT:**
-- **Phased Execution:** Break work into logical chunks (e.g., "Setup", "Core Logic", "API Layer", "Tests").
+- **Phased Execution:** Break work into logical chunks (e.g., "Setup", "Core Logic", "API Layer").
 - **Atomic Tasks:** Each task should be a single commit or PR.
 - **Verification Steps:** For each task, define how to verify it (e.g., "Run `npm test`", "Check linter").
 - **Dependency Order:** Ensure Task B implies Task A is done.
+
+**🔴🟢🔵 TDD STRUCTURE (Mandatory):**
+For each module/feature, structure tasks as:
+1. **RED:** Write failing tests first, with minimal stub implementation that compiles but fails tests
+2. **GREEN:** Implement just enough code to make tests pass
+3. **REFACTOR:** Clean up if needed (optional step, only if code is messy)
+
+Example task structure:
+- B1. Write Slug.test.ts (RED) — tests fail
+- B2. Implement Slug.ts (GREEN) — tests pass
 
 **🛑 FORBIDDEN IN THIS PHASE:**
 - **Time Estimates:** Do not estimate hours or days. Focus strictly on logical dependency and atomicity.
 - **Design Decisions:** If you are deciding *how* to do something here, go back to Phase 3.
 - **New Requirements:** If you find a missing requirement, go back to Phase 2.
+- **Implementation before tests:** Never write implementation code before the corresponding test exists.
 
 ---
 

--- a/.specs/AGENTS.md
+++ b/.specs/AGENTS.md
@@ -77,17 +77,23 @@ Use the **Easy Approach to Requirements Syntax** patterns. Format for readabilit
 **Objective:** Define the technical architecture and implementation strategy.
 
 **✅ CONTENT:**
-- **Data Models:** Interfaces, Types, Database Schemas.
-- **API Signatures:** Function names, inputs, outputs.
-- **Module Architecture:** File structure, exports, dependencies.
-- **Algorithms:** Pseudo-code or logic flow for complex parts.
-- **Error Handling Strategy:** Specific error types and recovery flows.
-- **Test Strategy:** Unit vs. Integration, mocking strategies.
+- **Data Models:** Type names and their fields (not full TypeScript syntax)
+- **API Signatures:** Function names, inputs, outputs as prose or tables
+- **Module Architecture:** File/folder structure, dependency relationships
+- **Algorithms:** Plain English or numbered steps for complex logic
+- **Error Handling Strategy:** Error categories and recovery approaches
+- **Test Strategy:** What to test and how (unit vs integration)
 
 **🛑 FORBIDDEN IN THIS PHASE:**
-- **Full Implementation:** Do not write the actual function bodies (use comments/pseudo-code).
+- **Code blocks:** No TypeScript, JavaScript, JSON, or any executable syntax
+- **Full implementations:** Describe WHAT functions do, not HOW (no function bodies)
+- **Copy-pasteable configs:** Describe package.json structure, don't write it out
+- **Test implementations:** Describe test cases in prose, don't write test code
 - **Vague Hand-waving:** Do not say "We will handle errors." Define *exactly* how.
 - **Scope Creep:** Do not add features not listed in `requirements.md`.
+
+**💡 RULE OF THUMB:**
+If it could be copy-pasted into a `.ts`, `.js`, or `.json` file and executed, it does NOT belong in design.md. Use prose, tables, bullet points, and diagrams instead.
 
 ---
 

--- a/.specs/note-basic/design.md
+++ b/.specs/note-basic/design.md
@@ -1,0 +1,124 @@
+# Design: note
+
+This document describes the architecture and implementation strategy for the `note` CLI tool.
+
+## Module Architecture
+
+```
+packages-native/note/
+├── src/
+│   ├── index.ts        # Library exports (Note, Slug, Validate)
+│   ├── bin.ts          # CLI implementation (command + run)
+│   ├── Note.ts         # Core note creation logic
+│   ├── Slug.ts         # Slug generation utility
+│   └── Validate.ts     # Argument validation (filename, flag, existing file detection)
+├── scripts/
+│   └── copy-bin.mjs    # Copies compiled bin to dist/
+├── test/
+│   ├── Slug.test.ts    # Slug unit tests
+│   ├── Validate.test.ts # Validation unit tests
+│   └── Note.test.ts    # Note function tests
+├── bin.mjs             # Smart loader: dist/bin.mjs → build/esm/bin.js fallback
+├── package.json
+├── tsconfig.json
+├── tsconfig.build.json
+├── tsconfig.src.json
+├── tsconfig.test.json
+└── vitest.config.ts
+```
+
+## Data Models
+
+### NoteOptions
+- `title`: string — the original title text with spaces preserved
+
+### NoteResult
+- `filename`: string — generated filename (e.g., `note-2025-11-26-my-title.md`)
+- `content`: string — the markdown content written to file
+
+### ValidationError
+- Tagged error type for argument validation failures
+- Fields: `type` (filename | flag | existing-file), `arg` (the problematic argument), `message` (user-facing explanation)
+
+## API Signatures
+
+| Module | Function | Inputs | Output | Description |
+|--------|----------|--------|--------|-------------|
+| Slug | `slugify` | title: string | string | Converts title to URL-safe slug |
+| Note | `makeFilename` | title: string, date: Date | string | Generates `note-YYYY-MM-DD-slug.md` filename |
+| Note | `makeContent` | title: string, timestamp: Date | string | Generates markdown content |
+| Note | `createNote` | options: NoteOptions | Effect\<NoteResult, PlatformError, FileSystem \| Path\> | Creates note file in cwd |
+| Validate | `looksLikeFilename` | arg: string | boolean | True if arg has dot and no spaces |
+| Validate | `looksLikeFlag` | arg: string | boolean | True if arg starts with `-`/`--` or contains `=` |
+| Validate | `validateArgs` | args: string[] | Effect\<void, ValidationError, FileSystem\> | Checks all args; fails if any look suspicious or match existing files |
+
+## Slug Algorithm
+
+1. Convert input to lowercase
+2. Replace all whitespace sequences with a single hyphen
+3. Remove all characters that are not alphanumeric or hyphens
+4. Collapse consecutive hyphens into one
+5. Trim leading and trailing hyphens
+
+## CLI Structure
+
+- Use `@effect/cli` Command and Args modules
+- Define variadic text args with `Args.repeated` and `Args.atLeast(1)` for title
+- Before processing, run `validateArgs` on raw args to detect misuse
+- On validation failure, show help text and exit non-zero
+- Join args with spaces to form title string
+- Provide `NodeContext.layer` for platform services
+- Run via `NodeRuntime.runMain`
+
+## Binary Entry Strategy
+
+- Single `bin.mjs` loader at package root serves both dev and dist scenarios
+- Loader checks for `dist/bin.mjs` first (published), falls back to `build/esm/bin.js` (development)
+- `scripts/copy-bin.mjs` copies `build/esm/bin.js` to `dist/bin.mjs` with execute permission during build
+- `package.json` bin field points to `./bin.mjs`
+
+## Package Configuration
+
+- Name: `note` (unscoped, top-level)
+- Type: ESM (`"type": "module"`)
+- Bin field maps `note` command to `./bin.mjs`
+- PublishConfig sets directory to `dist` for npm publishing
+- Dependencies: `@effect/cli`, `@effect/platform-node`, `effect`
+- Dev: `@effect/vitest`
+- Files: build, dist, src, bin.mjs, scripts, README.md, LICENSE, CHANGELOG.md
+
+## Error Handling Strategy
+
+| Error Scenario | Handling Approach |
+|----------------|-------------------|
+| No title provided | `@effect/cli` handles via `Args.atLeast(1)` — automatic error message |
+| Argument looks like filename | Check if arg contains dot and no spaces; abort with helpful message |
+| Argument matches existing file | Check filesystem before proceeding; abort with confusion warning |
+| Argument looks like flag/option | Check if arg starts with `-`/`--` or contains `=`; abort and show help |
+| File write failure | `FileSystem.writeFileString` returns `PlatformError` — surfaced by `NodeRuntime.runMain` |
+| Invalid slug (empty after processing) | Slug function returns empty string; caller should validate |
+
+## Test Strategy
+
+### Unit Tests (Slug.test.ts)
+- Lowercase conversion
+- Space to hyphen replacement
+- Special character removal
+- Multiple hyphen collapse
+- Leading/trailing hyphen trim
+- Empty input handling
+- Mixed case with special characters
+
+### Validation Tests (Validate.test.ts)
+- `looksLikeFilename`: true for "foo.md", "test.txt", false for "foo bar.md", "hello"
+- `looksLikeFlag`: true for "--help", "-v", "--key=val", false for "hello", "my-title"
+- `validateArgs`: fails when arg matches existing file in cwd
+
+### Function Tests (Note.test.ts)
+- `makeFilename` produces correct format given fixed date
+- `makeContent` produces correct markdown structure
+- Both functions handle edge cases (very long titles, unicode)
+
+### Integration Verification
+- Manual verification: run `npx note test title` and inspect output file
+- Build verification: `pnpm build`, `pnpm check`, `pnpm lint` pass

--- a/.specs/note-basic/design.md
+++ b/.specs/note-basic/design.md
@@ -50,7 +50,7 @@ packages-native/note/
 | Note | `createNote` | options: NoteOptions | Effect\<NoteResult, PlatformError, FileSystem \| Path\> | Creates note file in cwd |
 | Validate | `looksLikeFilename` | arg: string | boolean | True if arg has dot and no spaces |
 | Validate | `looksLikeFlag` | arg: string | boolean | True if arg starts with `-`/`--` or contains `=` |
-| Validate | `validateArgs` | args: string[] | Effect\<void, ValidationError, FileSystem\> | Checks all args; fails if any look suspicious or match existing files |
+| Validate | `TitleWord` | — | Schema\<string, string\> | Schema that validates a string is a plain title word |
 
 ## Slug Algorithm
 
@@ -62,11 +62,13 @@ packages-native/note/
 
 ## CLI Structure
 
-- Use `@effect/cli` Command and Args modules
-- Define variadic text args with `Args.repeated` and `Args.atLeast(1)` for title
-- Before processing, run `validateArgs` on raw args to detect misuse
-- On validation failure, show help text and exit non-zero
-- Join args with spaces to form title string
+- Use `@effect/cli` Command and Args modules with Effect Schema for validation
+- Define a `TitleWord` schema that validates each argument is plain text (not a flag/filename)
+- Use `Args.text` with schema refinement to reject invalid args at parse time
+- Schema checks: not starting with `-`, not containing `=`, not looking like a filename
+- Use `Args.repeated` and `Args.atLeast(1)` for variadic title words
+- Existing file check happens in the command handler (requires FileSystem)
+- Join validated args with spaces to form title string
 - Provide `NodeContext.layer` for platform services
 - Run via `NodeRuntime.runMain`
 

--- a/.specs/note-basic/instructions.md
+++ b/.specs/note-basic/instructions.md
@@ -1,0 +1,79 @@
+# note — Phase 1 Instructions
+
+## Overview
+
+A minimal CLI tool for creating timestamped markdown notes from the command line. The tool captures a title as positional arguments and generates a dated markdown file in the current directory.
+
+- Package name: `note` (top-level, unscoped)
+- Primary value: Quick note creation with consistent naming and timestamps
+- Example invocation: `npx note this is the title of my note`
+
+## Personas & User Stories
+
+1) Developer taking quick notes
+   - As a developer who wants to capture a thought quickly, I want to run a single command with my note title as arguments, so that a properly formatted markdown file is created without interrupting my flow.
+
+2) Documentation-oriented user
+   - As someone who organizes notes by date, I want the generated filename to include the current date, so that notes are naturally sorted chronologically in the filesystem.
+
+## Core Requirements
+
+- Accept note title as variadic positional arguments (all args after the command become the title)
+- Generate a markdown file with:
+  - Filename format: `note-YYYY-MM-DD-slugified-title.md`
+  - Header: `# original title with spaces`
+  - Timestamp line: `Created: YYYY-MM-DDTHH:MM:SS.sssZ` (ISO 8601)
+- Print confirmation: `Created: note-YYYY-MM-DD-slugified-title.md`
+- Write the file to the current working directory
+
+### Slug Rules
+
+- Convert title to lowercase
+- Replace spaces with hyphens
+- Strip or replace non-alphanumeric characters (except hyphens)
+- Collapse multiple consecutive hyphens
+
+### Dependencies
+
+- Use `@effect/cli` for command-line argument parsing
+- Use `@effect/platform` for filesystem operations
+- Use `@effect/platform-node` for Node.js runtime integration
+- Effect ecosystem peer dependencies
+
+## Acceptance Criteria
+
+- Running `npx note this is the title of my note` creates a file `note-2025-11-26-this-is-the-title-of-my-note.md`
+- File contents match the specified format:
+  ```md
+  # this is the title of my note
+
+  Created: 2025-11-26T14:30:56.886Z
+  ```
+- Success message printed to stdout: `Created: note-2025-11-26-this-is-the-title-of-my-note.md`
+- Exit code 0 on success
+- Informative error message and non-zero exit on failure (e.g., no title provided)
+- Full repository validations pass: lint, typecheck, tests, build
+
+## Out of Scope (v1)
+
+- Custom output directory (always writes to cwd)
+- Template customization
+- Tags or categories
+- Opening the file in an editor after creation
+- Reading from stdin
+- Interactive mode
+- Config file support
+
+## Success Metrics
+
+- 0 docgen/typecheck/lint/build errors in CI
+- Tests cover: title slugification, file generation, error cases
+- Clear, copy-pasteable example in README
+
+## Future Considerations
+
+- Optional `--dir` flag for custom output directory
+- Optional `--template` flag for custom templates
+- Optional `--open` flag to open in `$EDITOR`
+- Tag support via `--tag` flag
+- Integration with note-taking systems (Obsidian, Logseq, etc.)

--- a/.specs/note-basic/plan.md
+++ b/.specs/note-basic/plan.md
@@ -1,0 +1,156 @@
+# Plan: note
+
+This document provides a step-by-step execution checklist for implementing the `note` CLI package using **Red-Green-Refactor TDD** (write failing test first, then implement to make it pass).
+
+## Phase A: Package Scaffold
+
+### A1. Create package directory structure
+- Create `packages-native/note/` with `src/`, `test/`, `scripts/` subdirectories
+- **Verify:** Directory exists with correct structure
+
+### A2. Create package.json
+- Define name as `note` (unscoped)
+- Set type to `module`
+- Configure bin, exports, scripts, dependencies per design
+- **Verify:** `cat package.json` shows correct structure
+
+### A3. Create tsconfig files
+- Copy pattern from existing packages-native package (e.g., libsqlite)
+- Create tsconfig.json, tsconfig.build.json, tsconfig.src.json, tsconfig.test.json
+- **Verify:** `pnpm check` runs without config errors
+
+### A4. Create vitest.config.ts
+- Copy pattern from existing package
+- **Verify:** `pnpm test` runs (may have no tests yet)
+
+### A5. Create bin.mjs loader
+- Implement smart loader that checks dist/bin.mjs then build/esm/bin.js
+- **Verify:** File exists and is executable
+
+### A6. Create scripts/copy-bin.mjs
+- Implement build script to copy compiled bin to dist
+- **Verify:** Script exists
+
+### A7. Install dependencies
+- Run `pnpm install` from monorepo root
+- **Verify:** No install errors, node_modules linked
+
+## Phase B: Core Logic (TDD)
+
+### B1. Write Slug.test.ts (RED)
+- Write failing tests for all slug cases: lowercase, spaces, special chars, collapse, trim
+- Create minimal Slug.ts stub that exports `slugify` returning empty string
+- **Verify:** `pnpm test` runs, tests FAIL (red)
+
+### B2. Implement Slug.ts (GREEN)
+- Implement `slugify` function per design algorithm
+- **Verify:** `pnpm test` passes, all slug tests GREEN
+
+### B3. Write Validate.test.ts (RED)
+- Write failing tests for `looksLikeFilename`, `looksLikeFlag`
+- Create minimal Validate.ts stub with functions returning false
+- **Verify:** `pnpm test` runs, validation tests FAIL (red)
+
+### B4. Implement Validate.ts (GREEN)
+- Implement `looksLikeFilename`, `looksLikeFlag`, `validateArgs`
+- Define `ValidationError` tagged error
+- **Verify:** `pnpm test` passes, all validation tests GREEN
+
+### B5. Write Note.test.ts (RED)
+- Write failing tests for `makeFilename` and `makeContent` with fixed dates
+- Create minimal Note.ts stub with functions returning empty strings
+- **Verify:** `pnpm test` runs, note tests FAIL (red)
+
+### B6. Implement Note.ts (GREEN)
+- Implement `makeFilename`, `makeContent`, `createNote`
+- Export `NoteOptions`, `NoteResult` types
+- **Verify:** `pnpm test` passes, all note tests GREEN
+
+## Phase C: CLI Wiring
+
+### C1. Implement bin.ts
+- Import from Note, Slug, Validate modules
+- Define CLI command with Args.repeated + Args.atLeast(1)
+- Wire validation, note creation, and success output
+- Export `run` function for testability
+- **Verify:** `pnpm check` passes
+
+### C2. Implement index.ts
+- Re-export public API from Note, Slug, Validate
+- **Verify:** `pnpm check` passes
+
+### C3. Manual CLI test
+- Run `node --import tsx/esm bin.mjs test title here`
+- **Verify:** Creates file, prints success message
+
+### C4. Test validation errors
+- Run with filename-like arg, flag-like arg, existing file
+- **Verify:** Each case aborts with appropriate error message
+
+## Phase D: Build & Polish
+
+### D1. Run full build
+- `pnpm build`
+- **Verify:** build/esm/ and dist/ populated, no errors
+
+### D2. Test dist binary
+- Run `./bin.mjs another test` after build
+- **Verify:** Uses dist/bin.mjs, creates file correctly
+
+### D3. Run all checks
+- `pnpm check && pnpm lint && pnpm test`
+- **Verify:** All pass with zero errors
+
+### D4. Create README.md
+- Document usage, examples, API
+- **Verify:** File exists with proper content
+
+### D5. Create LICENSE and CHANGELOG.md
+- Copy LICENSE from another package
+- Create empty CHANGELOG.md
+- **Verify:** Files exist
+
+## Phase E: Integration
+
+### E1. Add to pnpm-workspace.yaml (if needed)
+- Ensure packages-native/note is included
+- **Verify:** `pnpm install` from root recognizes package
+
+### E2. Final validation
+- `pnpm build && pnpm check && pnpm lint && pnpm test` from package directory
+- **Verify:** All green
+
+### E3. Commit implementation
+- Stage all new files
+- Commit with descriptive message
+- **Verify:** `git status` clean
+
+## Progress Tracking
+
+| Task | Status | Evidence |
+|------|--------|----------|
+| A1 | ⬜ | |
+| A2 | ⬜ | |
+| A3 | ⬜ | |
+| A4 | ⬜ | |
+| A5 | ⬜ | |
+| A6 | ⬜ | |
+| A7 | ⬜ | |
+| B1 | ⬜ | |
+| B2 | ⬜ | |
+| B3 | ⬜ | |
+| B4 | ⬜ | |
+| B5 | ⬜ | |
+| B6 | ⬜ | |
+| C1 | ⬜ | |
+| C2 | ⬜ | |
+| C3 | ⬜ | |
+| C4 | ⬜ | |
+| D1 | ⬜ | |
+| D2 | ⬜ | |
+| D3 | ⬜ | |
+| D4 | ⬜ | |
+| D5 | ⬜ | |
+| E1 | ⬜ | |
+| E2 | ⬜ | |
+| E3 | ⬜ | |

--- a/.specs/note-basic/plan.md
+++ b/.specs/note-basic/plan.md
@@ -86,6 +86,7 @@ This document provides a step-by-step execution checklist for implementing the `
 ### C4. Test validation errors
 - Run with filename-like arg, flag-like arg, existing file
 - **Verify:** Each case aborts with appropriate error message
+- **Note:** Pretty error formatting (FR1.10) deferred pending guidance from Effect team on idiomatic approach
 
 ## Phase D: Build & Polish
 

--- a/.specs/note-basic/requirements.md
+++ b/.specs/note-basic/requirements.md
@@ -49,6 +49,11 @@ This document formalizes the requirements for a minimal CLI tool that creates ti
 - **When** the note content is generated,
   **then** the CLI shall write the file to the current working directory.
 
+### FR1.6.1 – No Overwrite
+- **If** a file with the generated filename already exists,
+  **then** the CLI shall abort with a non-zero code and print an error message indicating the file already exists.
+- **Rationale:** Prevents accidental data loss; user must explicitly handle conflicts.
+
 ### FR1.7 – Success Output
 - **When** the file is successfully created,
   **then** the CLI shall print to stdout: `✅ Created: <filename>`
@@ -60,6 +65,13 @@ This document formalizes the requirements for a minimal CLI tool that creates ti
 ### FR1.9 – Error Handling
 - **If** the file cannot be written (e.g., permission denied, disk full),
   **then** the CLI shall print an error message to stderr and exit with a non-zero code.
+
+### FR1.10 – Pretty Error Messages
+- **When** displaying error messages,
+  **then** the CLI shall:
+  - FR1.10.1: Show a concise, user-friendly message (not raw schema validation paths or stack traces)
+  - FR1.10.2: Include actionable guidance (e.g., "Usage: note <title words...>")
+  - FR1.10.3: Exit cleanly without logging internal Effect error structures
 
 ## NFR2 – Non-Functional Requirements
 

--- a/.specs/note-basic/requirements.md
+++ b/.specs/note-basic/requirements.md
@@ -1,0 +1,118 @@
+# Requirements: note
+
+This document formalizes the requirements for a minimal CLI tool that creates timestamped markdown notes from the command line.
+
+## FR1 – Functional Requirements
+
+### FR1.1 – Command Invocation
+- **When** the user runs `npx note <title words...>`,
+  **then** the CLI shall join all positional arguments into a title string separated by spaces.
+
+### FR1.2 – Title Validation
+- **When** no positional arguments are provided,
+  **then** the CLI shall exit with a non-zero code and print an error message indicating a title is required.
+
+### FR1.2.1 – Filename Argument Detection
+- **If** any positional argument appears to be a filename (contains a dot and no spaces),
+  **then** the CLI shall abort with a non-zero code and print an error message explaining that the tool creates filenames automatically and does not accept filename arguments.
+
+### FR1.2.2 – Existing File Detection  
+- **If** any positional argument matches an existing file in the current directory,
+  **then** the CLI shall abort with a non-zero code and print an error message indicating the user may have confused this tool with another command.
+
+### FR1.2.3 – Flag Argument Detection
+- **If** any positional argument appears to be a flag or option (starts with `-` or `--`, or contains `=`),
+  **then** the CLI shall abort with a non-zero code and display the help text.
+- **Rationale:** Preserves option space for future CLI flags; prevents users from developing habits that would break when flags are added later.
+
+### FR1.3 – Slug Generation
+- **When** generating the filename slug from the title,
+  **then** the CLI shall:
+  - FR1.3.1: Convert the title to lowercase
+  - FR1.3.2: Replace spaces with hyphens
+  - FR1.3.3: Remove characters that are not alphanumeric or hyphens
+  - FR1.3.4: Collapse consecutive hyphens into a single hyphen
+  - FR1.3.5: Trim leading and trailing hyphens
+
+### FR1.4 – Filename Format
+- The CLI shall generate filenames in the format: `note-YYYY-MM-DD-<slug>.md`
+- The date shall be the current local date in ISO format (YYYY-MM-DD).
+
+### FR1.5 – File Content
+- **When** creating the note file,
+  **then** the CLI shall write:
+  - FR1.5.1: A level-1 markdown heading containing the original title (preserving case and spaces)
+  - FR1.5.2: A blank line
+  - FR1.5.3: A line containing `Created: <ISO-8601-timestamp>` with full precision (e.g., `2025-11-26T14:30:56.886Z`)
+
+### FR1.6 – File Creation
+- **When** the note content is generated,
+  **then** the CLI shall write the file to the current working directory.
+
+### FR1.7 – Success Output
+- **When** the file is successfully created,
+  **then** the CLI shall print to stdout: `✅ Created: <filename>`
+
+### FR1.8 – Success Exit
+- **When** the file is successfully created,
+  **then** the CLI shall exit with code 0.
+
+### FR1.9 – Error Handling
+- **If** the file cannot be written (e.g., permission denied, disk full),
+  **then** the CLI shall print an error message to stderr and exit with a non-zero code.
+
+## NFR2 – Non-Functional Requirements
+
+### NFR2.1 – Performance
+- The CLI shall complete execution in under 500ms for typical usage.
+
+### NFR2.2 – Dependencies
+- The CLI shall use Effect ecosystem libraries (`@effect/cli`, `@effect/platform`, `@effect/platform-node`).
+- The CLI shall have minimal runtime dependencies.
+
+### NFR2.3 – Compatibility
+- The CLI shall support Node.js >= 20.19.6 LTS.
+- The CLI shall be executable via `npx note`.
+
+### NFR2.4 – Package Identity
+- The package shall be published as `note` (top-level, unscoped) on npm.
+
+## TC3 – Technical Constraints
+
+### TC3.1 – Package Location
+- The package shall reside at `packages-native/note/` in the monorepo.
+
+### TC3.2 – Build System
+- The package shall use the standard Effect monorepo build tooling (`@effect/build-utils`, tsconfig inheritance).
+
+### TC3.3 – Binary Entry
+- The `package.json` shall define a `bin` field mapping `note` to the compiled CLI entry point.
+
+### TC3.4 – ESM
+- The package shall be ESM-only (`"type": "module"`).
+
+## DR4 – Data Requirements
+
+### DR4.1 – Output File Schema
+```
+# <title>
+
+Created: <ISO-8601-timestamp>
+```
+
+### DR4.2 – Filename Schema
+```
+note-<YYYY-MM-DD>-<slug>.md
+```
+
+Where:
+- `YYYY-MM-DD` is the current local date
+- `slug` is the slugified title per FR1.3
+
+## SC5 – Success Criteria
+
+- SC5.1: `pnpm build`, `pnpm check`, `pnpm lint` pass with zero errors.
+- SC5.2: Unit tests cover slug generation edge cases (special characters, multiple spaces, empty after slugification).
+- SC5.3: Integration test verifies end-to-end file creation.
+- SC5.4: `npx note this is the title of my note` produces the expected file and output.
+- SC5.5: Error cases (no title, write failure) produce appropriate messages and exit codes.

--- a/packages-native/note/LICENSE
+++ b/packages-native/note/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Effect-Native
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages-native/note/README.md
+++ b/packages-native/note/README.md
@@ -1,0 +1,29 @@
+# `npx note`
+
+Create timestamped markdown notes from the command line.
+
+## Usage
+
+```bash
+npx note this is my title
+```
+
+```bash
+bunx note this is my title
+```
+
+```bash
+pnpm dlx note this is my title
+```
+
+Creates a file like `note-2025-11-26-this-is-my-title.md` with content:
+
+```markdown
+# this is my title
+
+Created: 2025-11-26T10:15:00.000Z
+```
+
+## License
+
+MIT

--- a/packages-native/note/bin.mjs
+++ b/packages-native/note/bin.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+/**
+ * Published entrypoint. Attempts to load the bundled CLI from `dist` first,
+ * then falls back to the local build output when running from source.
+ *
+ * @since 0.1.0
+ */
+import { existsSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const here = dirname(fileURLToPath(import.meta.url))
+const candidates = [
+  "../dist/bin.mjs",
+  "../build/esm/bin.js"
+]
+
+let loaded = false
+
+for (const candidate of candidates) {
+  const absolute = resolve(here, candidate)
+  if (existsSync(absolute)) {
+    await import(pathToFileURL(absolute).href)
+    loaded = true
+    break
+  }
+}
+
+if (!loaded) {
+  throw new Error("note: build output not found. Run `pnpm build` first.")
+}

--- a/packages-native/note/bin.mjs
+++ b/packages-native/note/bin.mjs
@@ -12,8 +12,8 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 
 const here = dirname(fileURLToPath(import.meta.url))
 const candidates = [
-  "../dist/bin.mjs",
-  "../build/esm/bin.js"
+  "./build/esm/bin.js",
+  "./dist/bin.mjs"
 ]
 
 let loaded = false

--- a/packages-native/note/package.json
+++ b/packages-native/note/package.json
@@ -20,7 +20,6 @@
     "./package.json": "./package.json",
     ".": "./src/index.ts",
     "./Note": "./src/Note.ts",
-    "./Slug": "./src/Slug.ts",
     "./Validate": "./src/Validate.ts",
     "./internal/*": null
   },
@@ -41,13 +40,14 @@
     "coverage": "vitest --coverage"
   },
   "dependencies": {
-    "@effect/cli": "workspace:*",
-    "@effect/platform": "workspace:*",
-    "@effect/platform-node": "workspace:*",
-    "effect": "workspace:*"
+    "@effect/cli": "^0.69.2",
+    "@effect/platform": "^0.91.1",
+    "@effect/platform-node": "^0.96.1",
+    "@effect-native/schemas": "workspace:*",
+    "effect": "^3.17.13"
   },
   "devDependencies": {
-    "@effect/vitest": "workspace:*"
+    "@effect/vitest": "^0.25.1"
   },
   "files": [
     "build",

--- a/packages-native/note/package.json
+++ b/packages-native/note/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "note",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "description": "Create timestamped markdown notes from the command line",
+  "homepage": "https://github.com/effect-native/effect-native/tree/main/packages-native/note",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/effect-native/effect-native",
+    "directory": "packages-native/note"
+  },
+  "bugs": {
+    "url": "https://github.com/effect-native/effect-native/issues"
+  },
+  "bin": {
+    "note": "./bin.mjs"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./Note": "./src/Note.ts",
+    "./Slug": "./src/Slug.ts",
+    "./Validate": "./src/Validate.ts",
+    "./internal/*": null
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "directory": "dist",
+    "linkDirectory": false
+  },
+  "scripts": {
+    "codegen": "echo 'note: skip codegen'",
+    "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3 && node ./scripts/copy-bin.mjs",
+    "build-esm": "tsc -b tsconfig.build.json",
+    "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
+    "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest --coverage"
+  },
+  "dependencies": {
+    "@effect/cli": "workspace:*",
+    "@effect/platform": "workspace:*",
+    "@effect/platform-node": "workspace:*",
+    "effect": "workspace:*"
+  },
+  "devDependencies": {
+    "@effect/vitest": "workspace:*"
+  },
+  "files": [
+    "build",
+    "dist",
+    "src",
+    "bin.mjs",
+    "scripts",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ]
+}

--- a/packages-native/note/scripts/copy-bin.mjs
+++ b/packages-native/note/scripts/copy-bin.mjs
@@ -1,0 +1,19 @@
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const pkgDir = dirname(fileURLToPath(import.meta.url))
+const root = resolve(pkgDir, "..")
+const source = resolve(root, "build/esm/bin.js")
+const target = resolve(root, "dist/bin.mjs")
+
+let content
+try {
+  content = await readFile(source, "utf8")
+} catch (error) {
+  throw new Error(`note: expected ESM build at ${source}`, { cause: error })
+}
+
+await mkdir(dirname(target), { recursive: true })
+await writeFile(target, content, "utf8")
+await chmod(target, 0o755)

--- a/packages-native/note/src/Note.ts
+++ b/packages-native/note/src/Note.ts
@@ -11,6 +11,12 @@ import { slugify } from "@effect-native/schemas/Slug"
  *
  * Format: `note-YYYY-MM-DD-<slug>.md`
  *
+ * @example
+ * import { makeFilename } from "note/Note"
+ *
+ * const date = new Date("2025-11-26T14:30:56.886Z")
+ * makeFilename("Hello World", date) // "note-2025-11-26-hello-world.md"
+ *
  * @since 0.1.0
  * @category Note
  */
@@ -29,6 +35,14 @@ export const makeFilename = (title: string, date: Date): string => {
  *
  * Created: <ISO-8601-timestamp>
  * ```
+ *
+ * @example
+ * import { makeContent } from "note/Note"
+ *
+ * const timestamp = new Date("2025-11-26T14:30:56.886Z")
+ * makeContent("My Note Title", timestamp)
+ * // Returns:
+ * // "# My Note Title\n\nCreated: 2025-11-26T14:30:56.886Z\n"
  *
  * @since 0.1.0
  * @category Note

--- a/packages-native/note/src/Note.ts
+++ b/packages-native/note/src/Note.ts
@@ -1,0 +1,37 @@
+/**
+ * Core note creation logic.
+ *
+ * @since 0.1.0
+ */
+
+import { slugify } from "@effect-native/schemas/Slug"
+
+/**
+ * Generates the note filename from title and date.
+ *
+ * Format: `note-YYYY-MM-DD-<slug>.md`
+ *
+ * @since 0.1.0
+ * @category Note
+ */
+export const makeFilename = (title: string, date: Date): string => {
+  const dateStr = date.toISOString().slice(0, 10)
+  const slug = slugify(title)
+  return `note-${dateStr}-${slug}.md`
+}
+
+/**
+ * Generates the note markdown content.
+ *
+ * Format:
+ * ```
+ * # <title>
+ *
+ * Created: <ISO-8601-timestamp>
+ * ```
+ *
+ * @since 0.1.0
+ * @category Note
+ */
+export const makeContent = (title: string, timestamp: Date): string =>
+  `# ${title}\n\nCreated: ${timestamp.toISOString()}\n`

--- a/packages-native/note/src/Validate.ts
+++ b/packages-native/note/src/Validate.ts
@@ -14,11 +14,17 @@ import * as Schema from "effect/Schema"
  * Returns true if the argument contains a dot AND has no spaces.
  * This catches cases like "file.md", "test.txt", "config.json".
  *
+ * @example
+ * import { looksLikeFilename } from "note/Validate"
+ *
+ * looksLikeFilename("file.md") // true
+ * looksLikeFilename("test.txt") // true
+ * looksLikeFilename("hello world") // false
+ *
  * @since 0.1.0
  * @category Validation
  */
-export const looksLikeFilename = (arg: string): boolean =>
-  arg.includes(".") && !arg.includes(" ")
+export const looksLikeFilename = (arg: string): boolean => arg.includes(".") && !arg.includes(" ")
 
 /**
  * Checks if an argument looks like a flag (starts with - or --, or contains =).
@@ -27,11 +33,18 @@ export const looksLikeFilename = (arg: string): boolean =>
  * - Starts with "-" (short flag or long flag)
  * - Contains "=" (key=value syntax)
  *
+ * @example
+ * import { looksLikeFlag } from "note/Validate"
+ *
+ * looksLikeFlag("--help") // true
+ * looksLikeFlag("-v") // true
+ * looksLikeFlag("key=value") // true
+ * looksLikeFlag("hello") // false
+ *
  * @since 0.1.0
  * @category Validation
  */
-export const looksLikeFlag = (arg: string): boolean =>
-  arg.startsWith("-") || arg.includes("=")
+export const looksLikeFlag = (arg: string): boolean => arg.startsWith("-") || arg.includes("=")
 
 /**
  * Schema that validates a string is a plain title word.
@@ -39,6 +52,14 @@ export const looksLikeFlag = (arg: string): boolean =>
  * Rejects strings that look like:
  * - Flags (starting with `-` or `--`, or containing `=`)
  * - Filenames (containing `.` with no spaces)
+ *
+ * @example
+ * import * as Schema from "effect/Schema"
+ * import { TitleWord } from "note/Validate"
+ *
+ * // Valid title words pass through
+ * Schema.decodeUnknownSync(TitleWord)("hello") // "hello"
+ * Schema.decodeUnknownSync(TitleWord)("my-title") // "my-title"
  *
  * @since 0.1.0
  * @category Schema
@@ -52,7 +73,8 @@ export const TitleWord = Schema.String.pipe(
   }),
   Schema.filter((s) => !looksLikeFilename(s), {
     message: (s) => ({
-      message: `"${s.actual}" looks like a filename. This tool creates filenames automatically.\nUsage: note <title words...>`,
+      message:
+        `"${s.actual}" looks like a filename. This tool creates filenames automatically.\nUsage: note <title words...>`,
       override: true
     })
   })
@@ -88,6 +110,13 @@ const MutableNonEmptyTitleWords = Schema.mutable(
  * into a TitleInput containing the derived title and slug.
  *
  * Uses mutable tuple type for compatibility with @effect/cli Args.atLeast(1).
+ *
+ * @example
+ * import * as Schema from "effect/Schema"
+ * import { TitleInput } from "note/Validate"
+ *
+ * const result = Schema.decodeUnknownSync(TitleInput)(["hello", "world"])
+ * // result: { words: ["hello", "world"], title: "hello world", slug: "hello-world" }
  *
  * @since 0.1.0
  * @category Schema

--- a/packages-native/note/src/Validate.ts
+++ b/packages-native/note/src/Validate.ts
@@ -1,0 +1,114 @@
+/**
+ * Argument validation utilities for the note CLI.
+ *
+ * @since 0.1.0
+ */
+
+import { slugify } from "@effect-native/schemas/Slug"
+import * as Array from "effect/Array"
+import * as Schema from "effect/Schema"
+
+/**
+ * Checks if an argument looks like a filename (has dot, no spaces).
+ *
+ * Returns true if the argument contains a dot AND has no spaces.
+ * This catches cases like "file.md", "test.txt", "config.json".
+ *
+ * @since 0.1.0
+ * @category Validation
+ */
+export const looksLikeFilename = (arg: string): boolean =>
+  arg.includes(".") && !arg.includes(" ")
+
+/**
+ * Checks if an argument looks like a flag (starts with - or --, or contains =).
+ *
+ * Returns true if the argument:
+ * - Starts with "-" (short flag or long flag)
+ * - Contains "=" (key=value syntax)
+ *
+ * @since 0.1.0
+ * @category Validation
+ */
+export const looksLikeFlag = (arg: string): boolean =>
+  arg.startsWith("-") || arg.includes("=")
+
+/**
+ * Schema that validates a string is a plain title word.
+ *
+ * Rejects strings that look like:
+ * - Flags (starting with `-` or `--`, or containing `=`)
+ * - Filenames (containing `.` with no spaces)
+ *
+ * @since 0.1.0
+ * @category Schema
+ */
+export const TitleWord = Schema.String.pipe(
+  Schema.filter((s) => !looksLikeFlag(s), {
+    message: (s) => ({
+      message: `"${s.actual}" looks like a flag. This tool doesn't accept flags yet.\nUsage: note <title words...>`,
+      override: true
+    })
+  }),
+  Schema.filter((s) => !looksLikeFilename(s), {
+    message: (s) => ({
+      message: `"${s.actual}" looks like a filename. This tool creates filenames automatically.\nUsage: note <title words...>`,
+      override: true
+    })
+  })
+)
+
+/**
+ * Parsed title input containing all derived values.
+ *
+ * @since 0.1.0
+ * @category Models
+ */
+export interface TitleInput {
+  /** Original words as provided */
+  readonly words: Array.NonEmptyReadonlyArray<string>
+  /** Joined title with spaces preserved */
+  readonly title: string
+  /** URL-safe slug derived from title */
+  readonly slug: string
+}
+
+/**
+ * Schema for mutable non-empty tuple [string, ...string[]] for @effect/cli compatibility.
+ *
+ * @since 0.1.0
+ * @category Schema
+ */
+const MutableNonEmptyTitleWords = Schema.mutable(
+  Schema.Tuple([TitleWord], TitleWord)
+)
+
+/**
+ * Schema that transforms a non-empty array of validated title words
+ * into a TitleInput containing the derived title and slug.
+ *
+ * Uses mutable tuple type for compatibility with @effect/cli Args.atLeast(1).
+ *
+ * @since 0.1.0
+ * @category Schema
+ */
+export const TitleInput: Schema.Schema<
+  TitleInput,
+  [string, ...Array<string>]
+> = Schema.transform(
+  MutableNonEmptyTitleWords,
+  Schema.Struct({
+    words: Schema.NonEmptyArray(Schema.String),
+    title: Schema.String,
+    slug: Schema.String
+  }),
+  {
+    strict: true,
+    decode: (words) => ({
+      words,
+      title: Array.join(words, " "),
+      slug: slugify(Array.join(words, " "))
+    }),
+    encode: ({ words }) => words as [string, ...Array<string>]
+  }
+)

--- a/packages-native/note/src/bin.ts
+++ b/packages-native/note/src/bin.ts
@@ -133,7 +133,7 @@ const noteCommand = Command.make(
         Effect.mapError((cause) => new WriteError({ filename, cause }))
       )
 
-      yield* Console.log(`Created: ${filename}`)
+      yield* Console.log(`\u2705 Created: ${filename}`)
     }).pipe(
       Effect.catchTag("ExistingArgFile", handleNoteError),
       Effect.catchTag("FileAlreadyExists", handleNoteError),
@@ -154,8 +154,10 @@ export const run = (args: ReadonlyArray<string>) =>
     version: "0.1.0"
   })(args)
 
-// Run if executed directly
-run(process.argv).pipe(
-  Effect.provide(NodeContext.layer),
-  NodeRuntime.runMain({ disableErrorReporting: true })
-)
+// Run if executed directly (not when imported as module for testing)
+if (process.argv[1]?.includes("bin")) {
+  run(process.argv).pipe(
+    Effect.provide(NodeContext.layer),
+    NodeRuntime.runMain({ disableErrorReporting: true })
+  )
+}

--- a/packages-native/note/src/bin.ts
+++ b/packages-native/note/src/bin.ts
@@ -157,5 +157,5 @@ export const run = (args: ReadonlyArray<string>) =>
 // Run if executed directly
 run(process.argv).pipe(
   Effect.provide(NodeContext.layer),
-  NodeRuntime.runMain({ disablePrettyLogger: true })
+  NodeRuntime.runMain({ disableErrorReporting: true })
 )

--- a/packages-native/note/src/bin.ts
+++ b/packages-native/note/src/bin.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+/**
+ * CLI entry point for the note command.
+ *
+ * @since 0.1.0
+ */
+
+import { Args, Command } from "@effect/cli"
+import { FileSystem, Path } from "@effect/platform"
+import { NodeContext, NodeRuntime } from "@effect/platform-node"
+import * as Console from "effect/Console"
+import * as Data from "effect/Data"
+import * as Effect from "effect/Effect"
+import * as Match from "effect/Match"
+
+import { makeContent, makeFilename } from "./Note.js"
+import { TitleInput } from "./Validate.js"
+
+/**
+ * CLI-specific errors with user-friendly messages.
+ *
+ * @since 0.1.0
+ * @category Errors
+ */
+export type NoteError = ExistingArgFile | FileAlreadyExists | WriteError
+
+/**
+ * Error when an argument matches an existing file in the current directory.
+ *
+ * @since 0.1.0
+ * @category Errors
+ */
+export class ExistingArgFile extends Data.TaggedError("ExistingArgFile")<{
+  readonly word: string
+}> {
+  get message() {
+    return `"${this.word}" matches an existing file. You may have confused this tool with another command.`
+  }
+}
+
+/**
+ * Error when the target note file already exists.
+ *
+ * @since 0.1.0
+ * @category Errors
+ */
+export class FileAlreadyExists extends Data.TaggedError("FileAlreadyExists")<{
+  readonly filename: string
+}> {
+  get message() {
+    return `File "${this.filename}" already exists. Choose a different title or remove the existing file.`
+  }
+}
+
+/**
+ * Error when file write fails.
+ *
+ * @since 0.1.0
+ * @category Errors
+ */
+export class WriteError extends Data.TaggedError("WriteError")<{
+  readonly filename: string
+  readonly cause: unknown
+}> {
+  get message() {
+    return `Failed to write "${this.filename}".`
+  }
+}
+
+/**
+ * Format a NoteError for display.
+ *
+ * @since 0.1.0
+ * @category Errors
+ */
+const formatError = (error: NoteError): string =>
+  Match.value(error).pipe(
+    Match.tag("ExistingArgFile", (e) => `Error: ${e.message}\nUsage: note <title words...>`),
+    Match.tag("FileAlreadyExists", (e) => `Error: ${e.message}`),
+    Match.tag("WriteError", (e) => `Error: ${e.message}`),
+    Match.exhaustive
+  )
+
+/**
+ * Handle NoteError by printing pretty message and exiting.
+ *
+ * @since 0.1.0
+ * @category Errors
+ */
+const handleNoteError = (error: NoteError): Effect.Effect<never> =>
+  Console.error(formatError(error)).pipe(
+    Effect.andThen(Effect.sync(() => process.exit(1)))
+  )
+
+const titleArgs = Args.text({ name: "title" }).pipe(
+  Args.atLeast(1),
+  Args.withSchema(TitleInput)
+)
+
+const noteCommand = Command.make(
+  "note",
+  { title: titleArgs },
+  ({ title }) =>
+    Effect.gen(function*() {
+      const fs = yield* FileSystem.FileSystem
+      const path = yield* Path.Path
+      const cwd = yield* Effect.sync(() => process.cwd())
+
+      // Check if any arg matches an existing file
+      for (const word of title.words) {
+        const filePath = path.join(cwd, word)
+        const exists = yield* fs.exists(filePath)
+        if (exists) {
+          return yield* new ExistingArgFile({ word })
+        }
+      }
+
+      // Generate filename and check if it already exists
+      const now = new Date()
+      const filename = makeFilename(title.title, now)
+      const filePath = path.join(cwd, filename)
+
+      const targetExists = yield* fs.exists(filePath)
+      if (targetExists) {
+        return yield* new FileAlreadyExists({ filename })
+      }
+
+      // Create the note
+      const content = makeContent(title.title, now)
+
+      yield* fs.writeFileString(filePath, content).pipe(
+        Effect.mapError((cause) => new WriteError({ filename, cause }))
+      )
+
+      yield* Console.log(`Created: ${filename}`)
+    }).pipe(
+      Effect.catchTag("ExistingArgFile", handleNoteError),
+      Effect.catchTag("FileAlreadyExists", handleNoteError),
+      Effect.catchTag("WriteError", handleNoteError)
+    )
+).pipe(
+  Command.withDescription("Create a timestamped markdown note")
+)
+
+/**
+ * Run the CLI with the given arguments.
+ *
+ * @since 0.1.0
+ */
+export const run = (args: ReadonlyArray<string>) =>
+  Command.run(noteCommand, {
+    name: "note",
+    version: "0.1.0"
+  })(args)
+
+// Run if executed directly
+run(process.argv).pipe(
+  Effect.provide(NodeContext.layer),
+  NodeRuntime.runMain({ disablePrettyLogger: true })
+)

--- a/packages-native/note/src/index.ts
+++ b/packages-native/note/src/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Note CLI - create timestamped markdown notes.
+ *
+ * @since 0.1.0
+ */
+
+/**
+ * Core note creation utilities.
+ *
+ * @since 0.1.0
+ */
+export * as Note from "./Note.js"
+
+/**
+ * Input validation schemas and utilities.
+ *
+ * @since 0.1.0
+ */
+export * as Validate from "./Validate.js"

--- a/packages-native/note/test/Note.test.ts
+++ b/packages-native/note/test/Note.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest"
-import { makeFilename, makeContent } from "../src/Note.js"
+import { makeContent, makeFilename } from "../src/Note.js"
 
 describe("makeFilename", () => {
   it("generates correct filename format", () => {

--- a/packages-native/note/test/Note.test.ts
+++ b/packages-native/note/test/Note.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "@effect/vitest"
+import { makeFilename, makeContent } from "../src/Note.js"
+
+describe("makeFilename", () => {
+  it("generates correct filename format", () => {
+    const date = new Date("2025-11-26T14:30:56.886Z")
+    const filename = makeFilename("this is the title of my note", date)
+    expect(filename).toBe("note-2025-11-26-this-is-the-title-of-my-note.md")
+  })
+
+  it("handles title with special characters", () => {
+    const date = new Date("2025-11-26T14:30:56.886Z")
+    const filename = makeFilename("Hello! World?", date)
+    expect(filename).toBe("note-2025-11-26-hello-world.md")
+  })
+
+  it("handles title with numbers", () => {
+    const date = new Date("2025-11-26T14:30:56.886Z")
+    const filename = makeFilename("Chapter 1 Introduction", date)
+    expect(filename).toBe("note-2025-11-26-chapter-1-introduction.md")
+  })
+})
+
+describe("makeContent", () => {
+  it("generates correct markdown content", () => {
+    const timestamp = new Date("2025-11-26T14:30:56.886Z")
+    const content = makeContent("this is the title of my note", timestamp)
+    expect(content).toBe(
+      "# this is the title of my note\n\nCreated: 2025-11-26T14:30:56.886Z\n"
+    )
+  })
+
+  it("preserves original title case", () => {
+    const timestamp = new Date("2025-11-26T14:30:56.886Z")
+    const content = makeContent("My Important Note", timestamp)
+    expect(content).toBe(
+      "# My Important Note\n\nCreated: 2025-11-26T14:30:56.886Z\n"
+    )
+  })
+
+  it("preserves spaces in title", () => {
+    const timestamp = new Date("2025-11-26T14:30:56.886Z")
+    const content = makeContent("hello   world", timestamp)
+    expect(content).toBe(
+      "# hello   world\n\nCreated: 2025-11-26T14:30:56.886Z\n"
+    )
+  })
+})

--- a/packages-native/note/test/Validate.test.ts
+++ b/packages-native/note/test/Validate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest"
 import * as Schema from "effect/Schema"
-import { looksLikeFilename, looksLikeFlag, TitleWord } from "../src/Validate.js"
+import { looksLikeFilename, looksLikeFlag, TitleInput, TitleWord } from "../src/Validate.js"
 
 describe("looksLikeFilename", () => {
   it("returns true for file.md", () => {
@@ -79,5 +79,40 @@ describe("TitleWord schema", () => {
 
   it("rejects filename-like strings", () => {
     expect(() => Schema.decodeUnknownSync(TitleWord)("file.md")).toThrow()
+  })
+})
+
+describe("TitleInput schema", () => {
+  it("transforms word array to TitleInput", () => {
+    const result = Schema.decodeUnknownSync(TitleInput)(["hello", "world"])
+    expect(result.words).toEqual(["hello", "world"])
+    expect(result.title).toBe("hello world")
+    expect(result.slug).toBe("hello-world")
+  })
+
+  it("handles single word", () => {
+    const result = Schema.decodeUnknownSync(TitleInput)(["hello"])
+    expect(result.words).toEqual(["hello"])
+    expect(result.title).toBe("hello")
+    expect(result.slug).toBe("hello")
+  })
+
+  it("handles special characters in words", () => {
+    const result = Schema.decodeUnknownSync(TitleInput)(["Hello!", "World?"])
+    expect(result.slug).toBe("hello-world")
+  })
+
+  it("handles numbers in words", () => {
+    const result = Schema.decodeUnknownSync(TitleInput)(["chapter", "1"])
+    expect(result.title).toBe("chapter 1")
+    expect(result.slug).toBe("chapter-1")
+  })
+
+  it("rejects flag-like words", () => {
+    expect(() => Schema.decodeUnknownSync(TitleInput)(["--help"])).toThrow()
+  })
+
+  it("rejects filename-like words", () => {
+    expect(() => Schema.decodeUnknownSync(TitleInput)(["file.md"])).toThrow()
   })
 })

--- a/packages-native/note/test/Validate.test.ts
+++ b/packages-native/note/test/Validate.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "@effect/vitest"
+import * as Schema from "effect/Schema"
+import { looksLikeFilename, looksLikeFlag, TitleWord } from "../src/Validate.js"
+
+describe("looksLikeFilename", () => {
+  it("returns true for file.md", () => {
+    expect(looksLikeFilename("file.md")).toBe(true)
+  })
+
+  it("returns true for test.txt", () => {
+    expect(looksLikeFilename("test.txt")).toBe(true)
+  })
+
+  it("returns true for config.json", () => {
+    expect(looksLikeFilename("config.json")).toBe(true)
+  })
+
+  it("returns false for words with spaces and dots", () => {
+    expect(looksLikeFilename("foo bar.md")).toBe(false)
+  })
+
+  it("returns false for plain word", () => {
+    expect(looksLikeFilename("hello")).toBe(false)
+  })
+
+  it("returns false for hyphenated words", () => {
+    expect(looksLikeFilename("my-title")).toBe(false)
+  })
+
+  it("returns false for words without extension", () => {
+    expect(looksLikeFilename("README")).toBe(false)
+  })
+})
+
+describe("looksLikeFlag", () => {
+  it("returns true for --help", () => {
+    expect(looksLikeFlag("--help")).toBe(true)
+  })
+
+  it("returns true for -v", () => {
+    expect(looksLikeFlag("-v")).toBe(true)
+  })
+
+  it("returns true for --key=value", () => {
+    expect(looksLikeFlag("--key=value")).toBe(true)
+  })
+
+  it("returns true for key=value (contains equals)", () => {
+    expect(looksLikeFlag("key=value")).toBe(true)
+  })
+
+  it("returns false for hello", () => {
+    expect(looksLikeFlag("hello")).toBe(false)
+  })
+
+  it("returns false for my-title", () => {
+    expect(looksLikeFlag("my-title")).toBe(false)
+  })
+
+  it("returns false for hyphenated-word", () => {
+    expect(looksLikeFlag("hyphenated-word")).toBe(false)
+  })
+})
+
+describe("TitleWord schema", () => {
+  it("accepts plain words", () => {
+    const result = Schema.decodeUnknownSync(TitleWord)("hello")
+    expect(result).toBe("hello")
+  })
+
+  it("accepts hyphenated words", () => {
+    const result = Schema.decodeUnknownSync(TitleWord)("my-title")
+    expect(result).toBe("my-title")
+  })
+
+  it("rejects flag-like strings", () => {
+    expect(() => Schema.decodeUnknownSync(TitleWord)("--help")).toThrow()
+  })
+
+  it("rejects filename-like strings", () => {
+    expect(() => Schema.decodeUnknownSync(TitleWord)("file.md")).toThrow()
+  })
+})

--- a/packages-native/note/test/bin.test.ts
+++ b/packages-native/note/test/bin.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "@effect/vitest"
+import { ExistingArgFile, FileAlreadyExists, WriteError } from "../src/bin.js"
+
+describe("NoteError classes", () => {
+  describe("ExistingArgFile", () => {
+    it("has correct message with word", () => {
+      const error = new ExistingArgFile({ word: "test.txt" })
+      expect(error.message).toContain("test.txt")
+      expect(error.message).toContain("existing file")
+    })
+
+    it("has correct tag", () => {
+      const error = new ExistingArgFile({ word: "foo" })
+      expect(error._tag).toBe("ExistingArgFile")
+    })
+  })
+
+  describe("FileAlreadyExists", () => {
+    it("has correct message with filename", () => {
+      const error = new FileAlreadyExists({ filename: "note-2025-11-26-test.md" })
+      expect(error.message).toContain("note-2025-11-26-test.md")
+      expect(error.message).toContain("already exists")
+    })
+
+    it("has correct tag", () => {
+      const error = new FileAlreadyExists({ filename: "note.md" })
+      expect(error._tag).toBe("FileAlreadyExists")
+    })
+  })
+
+  describe("WriteError", () => {
+    it("has correct message with filename", () => {
+      const error = new WriteError({ filename: "note.md", cause: new Error("EACCES") })
+      expect(error.message).toContain("note.md")
+      expect(error.message).toContain("Failed to write")
+    })
+
+    it("has correct tag", () => {
+      const error = new WriteError({ filename: "note.md", cause: null })
+      expect(error._tag).toBe("WriteError")
+    })
+
+    it("preserves cause", () => {
+      const cause = new Error("Permission denied")
+      const error = new WriteError({ filename: "note.md", cause })
+      expect(error.cause).toBe(cause)
+    })
+  })
+})

--- a/packages-native/note/tsconfig.build.json
+++ b/packages-native/note/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.src.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/build.tsbuildinfo",
+    "outDir": "build/esm",
+    "declarationDir": "build/dts",
+    "stripInternal": true
+  },
+  "exclude": []
+}

--- a/packages-native/note/tsconfig.json
+++ b/packages-native/note/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [],
+  "references": [
+    { "path": "tsconfig.src.json" },
+    { "path": "tsconfig.test.json" }
+  ]
+}

--- a/packages-native/note/tsconfig.src.json
+++ b/packages-native/note/tsconfig.src.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "rootDir": "src",
+    "outDir": "build/src",
+    "types": ["node"]
+  }
+}

--- a/packages-native/note/tsconfig.test.json
+++ b/packages-native/note/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["test"],
+  "references": [
+    { "path": "tsconfig.src.json" }
+  ],
+  "compilerOptions": {
+    "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
+    "rootDir": "test",
+    "noEmit": true
+  }
+}

--- a/packages-native/note/vitest.config.ts
+++ b/packages-native/note/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from "vitest/config"
+import shared from "../../vitest.shared"
+
+export default defineConfig(shared as any)

--- a/packages-native/note/vitest.config.ts
+++ b/packages-native/note/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config"
+import { mergeConfig } from "vitest/config"
 import shared from "../../vitest.shared"
 
-export default defineConfig(shared as any)
+export default mergeConfig(shared, {})

--- a/packages-native/schemas/LICENSE
+++ b/packages-native/schemas/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Effect-Native
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages-native/schemas/README.md
+++ b/packages-native/schemas/README.md
@@ -1,0 +1,33 @@
+# @effect-native/schemas
+
+Reusable Effect Schema definitions for common data types.
+
+## Installation
+
+```bash
+npm install @effect-native/schemas
+```
+
+## Modules
+
+### Slug
+
+Utilities for generating URL-safe slugs from strings.
+
+```typescript
+import { slugify, Slug, SlugBranded } from "@effect-native/schemas/Slug"
+
+// Function
+slugify("Hello World") // "hello-world"
+
+// Schema (transforms input to slug)
+import * as Schema from "effect/Schema"
+Schema.decodeUnknownSync(Slug)("Hello World") // "hello-world"
+
+// Branded Schema (transforms and brands the result)
+Schema.decodeUnknownSync(SlugBranded)("Hello World") // "hello-world" as SlugBrand
+```
+
+## License
+
+MIT

--- a/packages-native/schemas/package.json
+++ b/packages-native/schemas/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@effect-native/schemas",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "description": "Reusable Effect Schema definitions for common data types.",
+  "homepage": "https://github.com/effect-native/effect-native",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/effect-native/effect-native.git",
+    "directory": "packages-native/schemas"
+  },
+  "bugs": {
+    "url": "https://github.com/effect-native/effect-native/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "directory": "dist",
+    "linkDirectory": false
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./internal/*": null
+  },
+  "scripts": {
+    "codegen": "echo '@effect-native/schemas: nothing to codegen'",
+    "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3",
+    "build-esm": "tsc -b tsconfig.build.json",
+    "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
+    "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest --coverage"
+  },
+  "peerDependencies": {
+    "effect": "*"
+  },
+  "devDependencies": {
+    "effect": "latest",
+    "@effect/vitest": "latest"
+  }
+}

--- a/packages-native/schemas/src/Slug.ts
+++ b/packages-native/schemas/src/Slug.ts
@@ -16,6 +16,12 @@ import * as Schema from "effect/Schema"
  * 4. Collapse consecutive hyphens
  * 5. Trim leading/trailing hyphens
  *
+ * @example
+ * import { slugify } from "@effect-native/schemas/Slug"
+ *
+ * slugify("Hello World") // "hello-world"
+ * slugify("This is My Title!") // "this-is-my-title"
+ *
  * @since 0.1.0
  * @category Slug
  */
@@ -29,6 +35,12 @@ export const slugify = (title: string): string =>
 
 /**
  * Schema that transforms a string into its slug form.
+ *
+ * @example
+ * import * as Schema from "effect/Schema"
+ * import { Slug } from "@effect-native/schemas/Slug"
+ *
+ * Schema.decodeUnknownSync(Slug)("Hello World") // "hello-world"
  *
  * @since 0.1.0
  * @category Schema
@@ -60,6 +72,13 @@ export type SlugBrand = typeof SlugBrandedString.Type
  * Schema for a branded slug type.
  *
  * The input string is slugified and branded.
+ *
+ * @example
+ * import * as Schema from "effect/Schema"
+ * import { SlugBranded } from "@effect-native/schemas/Slug"
+ *
+ * const slug = Schema.decodeUnknownSync(SlugBranded)("Hello World")
+ * // slug: SlugBrand = "hello-world"
  *
  * @since 0.1.0
  * @category Schema

--- a/packages-native/schemas/src/Slug.ts
+++ b/packages-native/schemas/src/Slug.ts
@@ -1,0 +1,75 @@
+/**
+ * Slug generation utilities and schemas.
+ *
+ * @since 0.1.0
+ */
+
+import * as Schema from "effect/Schema"
+
+/**
+ * Converts a title string to a URL-safe slug.
+ *
+ * Algorithm:
+ * 1. Convert to lowercase
+ * 2. Replace whitespace sequences with hyphens
+ * 3. Remove non-alphanumeric characters (except hyphens)
+ * 4. Collapse consecutive hyphens
+ * 5. Trim leading/trailing hyphens
+ *
+ * @since 0.1.0
+ * @category Slug
+ */
+export const slugify = (title: string): string =>
+  title
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+
+/**
+ * Schema that transforms a string into its slug form.
+ *
+ * @since 0.1.0
+ * @category Schema
+ */
+export const Slug: Schema.Schema<string, string> = Schema.transform(
+  Schema.String,
+  Schema.String,
+  {
+    strict: true,
+    decode: slugify,
+    encode: (slug) => slug
+  }
+)
+
+/**
+ * Internal branded string schema for Slug.
+ */
+const SlugBrandedString = Schema.String.pipe(Schema.brand("Slug"))
+
+/**
+ * Brand type for slugified strings.
+ *
+ * @since 0.1.0
+ * @category Brands
+ */
+export type SlugBrand = typeof SlugBrandedString.Type
+
+/**
+ * Schema for a branded slug type.
+ *
+ * The input string is slugified and branded.
+ *
+ * @since 0.1.0
+ * @category Schema
+ */
+export const SlugBranded: Schema.Schema<SlugBrand, string> = Schema.transform(
+  Schema.String,
+  SlugBrandedString,
+  {
+    strict: true,
+    decode: slugify,
+    encode: (slug) => slug
+  }
+)

--- a/packages-native/schemas/src/index.ts
+++ b/packages-native/schemas/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @effect-native/schemas - Reusable Effect Schema definitions
+ *
+ * @since 0.1.0
+ */
+
+export * as Slug from "./Slug.js"

--- a/packages-native/schemas/test/Slug.test.ts
+++ b/packages-native/schemas/test/Slug.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "@effect/vitest"
+import * as Schema from "effect/Schema"
+import { Slug, SlugBranded, slugify } from "../src/Slug.js"
+
+describe("slugify", () => {
+  it("converts to lowercase", () => {
+    expect(slugify("Hello World")).toBe("hello-world")
+  })
+
+  it("replaces spaces with hyphens", () => {
+    expect(slugify("this is a test")).toBe("this-is-a-test")
+  })
+
+  it("removes special characters", () => {
+    expect(slugify("Hello! World?")).toBe("hello-world")
+  })
+
+  it("collapses multiple spaces into single hyphen", () => {
+    expect(slugify("hello   world")).toBe("hello-world")
+  })
+
+  it("collapses multiple hyphens into single hyphen", () => {
+    expect(slugify("hello---world")).toBe("hello-world")
+  })
+
+  it("trims leading hyphens", () => {
+    expect(slugify("  hello world")).toBe("hello-world")
+  })
+
+  it("trims trailing hyphens", () => {
+    expect(slugify("hello world  ")).toBe("hello-world")
+  })
+
+  it("handles mixed case and special chars", () => {
+    expect(slugify("This is My Title!")).toBe("this-is-my-title")
+  })
+
+  it("handles numbers", () => {
+    expect(slugify("Chapter 1 Introduction")).toBe("chapter-1-introduction")
+  })
+
+  it("handles empty string", () => {
+    expect(slugify("")).toBe("")
+  })
+
+  it("handles string with only special characters", () => {
+    expect(slugify("!@#$%")).toBe("")
+  })
+
+  it("handles the example from requirements", () => {
+    expect(slugify("this is the title of my note")).toBe("this-is-the-title-of-my-note")
+  })
+})
+
+describe("Slug schema", () => {
+  it("transforms input to slug", () => {
+    const result = Schema.decodeUnknownSync(Slug)("Hello World")
+    expect(result).toBe("hello-world")
+  })
+
+  it("encodes slug as-is", () => {
+    const result = Schema.encodeSync(Slug)("hello-world")
+    expect(result).toBe("hello-world")
+  })
+})
+
+describe("SlugBranded schema", () => {
+  it("transforms input to branded slug", () => {
+    const result = Schema.decodeUnknownSync(SlugBranded)("Hello World")
+    expect(result).toBe("hello-world")
+  })
+
+  it("encodes branded slug as-is", () => {
+    const result = Schema.encodeSync(SlugBranded)("hello-world" as any)
+    expect(result).toBe("hello-world")
+  })
+})

--- a/packages-native/schemas/tsconfig.build.json
+++ b/packages-native/schemas/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {
+    "outDir": "build/esm",
+    "declarationDir": "build/dts",
+    "rootDir": "src"
+  },
+  "references": []
+}

--- a/packages-native/schemas/tsconfig.json
+++ b/packages-native/schemas/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [],
+  "references": [
+    { "path": "tsconfig.src.json" },
+    { "path": "tsconfig.test.json" }
+  ]
+}

--- a/packages-native/schemas/tsconfig.src.json
+++ b/packages-native/schemas/tsconfig.src.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {
+    "outDir": "build/src",
+    "rootDir": "src"
+  },
+  "references": []
+}

--- a/packages-native/schemas/tsconfig.test.json
+++ b/packages-native/schemas/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["test/**/*.test.ts"],
+  "compilerOptions": {
+    "outDir": "build/test",
+    "rootDir": "test"
+  },
+  "references": [
+    { "path": "tsconfig.src.json" }
+  ]
+}

--- a/packages-native/schemas/vitest.config.ts
+++ b/packages-native/schemas/vitest.config.ts
@@ -1,0 +1,6 @@
+import { mergeConfig, type ViteUserConfig } from "vitest/config"
+import shared from "../../vitest.shared.ts"
+
+const config: ViteUserConfig = {}
+
+export default mergeConfig(shared, config)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 0.23.5
       '@effect/vitest':
         specifier: latest
-        version: 0.26.0(effect@3.18.4)(vitest@3.2.4)
+        version: 0.26.0(effect@3.19.6)(vitest@3.2.4)
       '@eslint/compat':
         specifier: ^1.3.2
         version: 1.4.0(eslint@9.37.0)
@@ -238,22 +238,6 @@ importers:
         version: 8.18.3
     publishDirectory: dist
 
-  packages-native/debug-demos:
-    dependencies:
-      effect:
-        specifier: latest
-        version: 3.18.4
-    devDependencies:
-      '@types/node':
-        specifier: ^22.0.0
-        version: 22.18.8
-      tsx:
-        specifier: ^4.19.0
-        version: 4.20.6
-      typescript:
-        specifier: ^5.6.0
-        version: 5.9.3
-
   packages-native/effect-native:
     dependencies:
       '@effect/cli':
@@ -284,6 +268,29 @@ importers:
         version: 3.18.4
     publishDirectory: dist
 
+  packages-native/note:
+    dependencies:
+      '@effect-native/schemas':
+        specifier: workspace:*
+        version: link:../schemas
+      '@effect/cli':
+        specifier: ^0.69.2
+        version: 0.69.2(@effect/platform@0.91.1(effect@3.19.6))(@effect/printer-ansi@0.46.0(@effect/typeclass@0.37.0(effect@3.19.6))(effect@3.19.6))(@effect/printer@0.46.0(@effect/typeclass@0.37.0(effect@3.19.6))(effect@3.19.6))(effect@3.19.6)
+      '@effect/platform':
+        specifier: ^0.91.1
+        version: 0.91.1(effect@3.19.6)
+      '@effect/platform-node':
+        specifier: ^0.96.1
+        version: 0.96.1(@effect/cluster@0.50.4(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6)
+      effect:
+        specifier: latest
+        version: 3.19.6
+    devDependencies:
+      '@effect/vitest':
+        specifier: ^0.25.1
+        version: 0.25.1(effect@3.19.6)(vitest@3.2.4)
+    publishDirectory: dist
+
   packages-native/patterns:
     dependencies:
       effect:
@@ -293,6 +300,17 @@ importers:
       '@effect/vitest':
         specifier: latest
         version: 0.26.0(effect@3.18.4)(vitest@3.2.4)
+    publishDirectory: dist
+
+  packages-native/schemas:
+    dependencies:
+      effect:
+        specifier: latest
+        version: 3.19.6
+    devDependencies:
+      '@effect/vitest':
+        specifier: latest
+        version: 0.27.0(effect@3.19.6)(vitest@3.2.4)
     publishDirectory: dist
 
   scratchpad:
@@ -1273,6 +1291,12 @@ packages:
     resolution: {integrity: sha512-h7r21XRtHpl8CQmIuplCK54bYJkUij4c6bUxK27y4d9dTXn4s7c/I3Lilb4VZxv3P3S3sChCu5YIGW4pdQFjZg==}
     peerDependencies:
       effect: ^3.18.0
+      vitest: ^3.2.0
+
+  '@effect/vitest@0.27.0':
+    resolution: {integrity: sha512-8bM7n9xlMUYw9GqPIVgXFwFm2jf27m/R7psI64PGpwU5+26iwyxp9eAXEsfT5S6lqztYfpQQ1Ubp5o6HfNYzJQ==}
+    peerDependencies:
+      effect: ^3.19.0
       vitest: ^3.2.0
 
   '@effect/wa-sqlite@0.1.2':
@@ -3141,6 +3165,9 @@ packages:
 
   effect@3.18.4:
     resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
+
+  effect@3.19.6:
+    resolution: {integrity: sha512-Eh1E/CI+xCAcMSDC5DtyE29yWJINC0zwBbwHappQPorjKyS69rCA8qzpsHpfhKnPDYgxdg8zkknii8mZ+6YMQA==}
 
   electron-to-chromium@1.5.233:
     resolution: {integrity: sha512-iUdTQSf7EFXsDdQsp8MwJz5SVk4APEFqXU/S47OtQ0YLqacSwPXdZ5vRlMX3neb07Cy2vgioNuRnWUXFwuslkg==}
@@ -6669,6 +6696,16 @@ snapshots:
       toml: 3.0.0
       yaml: 2.8.1
 
+  '@effect/cli@0.69.2(@effect/platform@0.91.1(effect@3.19.6))(@effect/printer-ansi@0.46.0(@effect/typeclass@0.37.0(effect@3.19.6))(effect@3.19.6))(@effect/printer@0.46.0(@effect/typeclass@0.37.0(effect@3.19.6))(effect@3.19.6))(effect@3.19.6)':
+    dependencies:
+      '@effect/platform': 0.91.1(effect@3.19.6)
+      '@effect/printer': 0.46.0(@effect/typeclass@0.37.0(effect@3.19.6))(effect@3.19.6)
+      '@effect/printer-ansi': 0.46.0(@effect/typeclass@0.37.0(effect@3.19.6))(effect@3.19.6)
+      effect: 3.19.6
+      ini: 4.1.3
+      toml: 3.0.0
+      yaml: 2.8.1
+
   '@effect/cli@0.69.2(@effect/platform@0.92.1(effect@3.18.4))(@effect/printer-ansi@0.46.0(@effect/typeclass@0.37.0(effect@3.18.4))(effect@3.18.4))(@effect/printer@0.46.0(@effect/typeclass@0.37.0(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)':
     dependencies:
       '@effect/platform': 0.92.1(effect@3.18.4)
@@ -6705,6 +6742,14 @@ snapshots:
       '@effect/workflow': 0.11.3(@effect/platform@0.91.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)
       effect: 3.18.4
 
+  '@effect/cluster@0.50.4(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6))(effect@3.19.6)':
+    dependencies:
+      '@effect/platform': 0.91.1(effect@3.19.6)
+      '@effect/rpc': 0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6)
+      '@effect/sql': 0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6)
+      '@effect/workflow': 0.11.3(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6)
+      effect: 3.19.6
+
   '@effect/cluster@0.50.4(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)':
     dependencies:
       '@effect/platform': 0.92.1(effect@3.18.4)
@@ -6738,6 +6783,12 @@ snapshots:
     dependencies:
       '@effect/platform': 0.91.1(effect@3.18.4)
       effect: 3.18.4
+      uuid: 11.1.0
+
+  '@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6)':
+    dependencies:
+      '@effect/platform': 0.91.1(effect@3.19.6)
+      effect: 3.19.6
       uuid: 11.1.0
 
   '@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)':
@@ -6802,6 +6853,20 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@effect/platform-node-shared@0.49.2(@effect/cluster@0.50.4(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6)':
+    dependencies:
+      '@effect/cluster': 0.50.4(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6))(effect@3.19.6)
+      '@effect/platform': 0.91.1(effect@3.19.6)
+      '@effect/rpc': 0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6)
+      '@effect/sql': 0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6)
+      '@parcel/watcher': 2.5.1
+      effect: 3.19.6
+      multipasta: 0.2.7
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@effect/platform-node-shared@0.49.2(@effect/cluster@0.50.4(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)':
     dependencies:
       '@effect/cluster': 0.50.4(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)
@@ -6852,6 +6917,21 @@ snapshots:
       '@effect/rpc': 0.71.0(@effect/platform@0.90.10(effect@3.18.4))(effect@3.18.4)
       '@effect/sql': 0.44.2(@effect/experimental@0.54.6(@effect/platform@0.90.10(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.90.10(effect@3.18.4))(effect@3.18.4)
       effect: 3.18.4
+      mime: 3.0.0
+      undici: 7.16.0
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node@0.96.1(@effect/cluster@0.50.4(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6)':
+    dependencies:
+      '@effect/cluster': 0.50.4(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6))(effect@3.19.6)
+      '@effect/platform': 0.91.1(effect@3.19.6)
+      '@effect/platform-node-shared': 0.49.2(@effect/cluster@0.50.4(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6)
+      '@effect/rpc': 0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6)
+      '@effect/sql': 0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6)
+      effect: 3.19.6
       mime: 3.0.0
       undici: 7.16.0
       ws: 8.18.3
@@ -6918,6 +6998,13 @@ snapshots:
       msgpackr: 1.11.5
       multipasta: 0.2.7
 
+  '@effect/platform@0.91.1(effect@3.19.6)':
+    dependencies:
+      effect: 3.19.6
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.11.5
+      multipasta: 0.2.7
+
   '@effect/platform@0.92.1(effect@3.18.4)':
     dependencies:
       effect: 3.18.4
@@ -6931,10 +7018,21 @@ snapshots:
       '@effect/typeclass': 0.37.0(effect@3.18.4)
       effect: 3.18.4
 
+  '@effect/printer-ansi@0.46.0(@effect/typeclass@0.37.0(effect@3.19.6))(effect@3.19.6)':
+    dependencies:
+      '@effect/printer': 0.46.0(@effect/typeclass@0.37.0(effect@3.19.6))(effect@3.19.6)
+      '@effect/typeclass': 0.37.0(effect@3.19.6)
+      effect: 3.19.6
+
   '@effect/printer@0.46.0(@effect/typeclass@0.37.0(effect@3.18.4))(effect@3.18.4)':
     dependencies:
       '@effect/typeclass': 0.37.0(effect@3.18.4)
       effect: 3.18.4
+
+  '@effect/printer@0.46.0(@effect/typeclass@0.37.0(effect@3.19.6))(effect@3.19.6)':
+    dependencies:
+      '@effect/typeclass': 0.37.0(effect@3.19.6)
+      effect: 3.19.6
 
   '@effect/rpc@0.71.0(@effect/platform@0.90.10(effect@3.18.4))(effect@3.18.4)':
     dependencies:
@@ -6946,6 +7044,12 @@ snapshots:
     dependencies:
       '@effect/platform': 0.91.1(effect@3.18.4)
       effect: 3.18.4
+      msgpackr: 1.11.5
+
+  '@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6)':
+    dependencies:
+      '@effect/platform': 0.91.1(effect@3.19.6)
+      effect: 3.19.6
       msgpackr: 1.11.5
 
   '@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)':
@@ -7086,6 +7190,13 @@ snapshots:
       effect: 3.18.4
       uuid: 11.1.0
 
+  '@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6)':
+    dependencies:
+      '@effect/experimental': 0.56.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6)
+      '@effect/platform': 0.91.1(effect@3.19.6)
+      effect: 3.19.6
+      uuid: 11.1.0
+
   '@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)':
     dependencies:
       '@effect/experimental': 0.56.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)
@@ -7097,14 +7208,33 @@ snapshots:
     dependencies:
       effect: 3.18.4
 
+  '@effect/typeclass@0.37.0(effect@3.19.6)':
+    dependencies:
+      effect: 3.19.6
+
   '@effect/vitest@0.25.1(effect@3.18.4)(vitest@3.2.4)':
     dependencies:
       effect: 3.18.4
       vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.18.8)(@vitest/browser@3.2.4)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
+  '@effect/vitest@0.25.1(effect@3.19.6)(vitest@3.2.4)':
+    dependencies:
+      effect: 3.19.6
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.18.8)(@vitest/browser@3.2.4)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+
   '@effect/vitest@0.26.0(effect@3.18.4)(vitest@3.2.4)':
     dependencies:
       effect: 3.18.4
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.18.8)(@vitest/browser@3.2.4)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+
+  '@effect/vitest@0.26.0(effect@3.19.6)(vitest@3.2.4)':
+    dependencies:
+      effect: 3.19.6
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.18.8)(@vitest/browser@3.2.4)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+
+  '@effect/vitest@0.27.0(effect@3.19.6)(vitest@3.2.4)':
+    dependencies:
+      effect: 3.19.6
       vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/node@22.18.8)(@vitest/browser@3.2.4)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   '@effect/wa-sqlite@0.1.2': {}
@@ -7120,6 +7250,12 @@ snapshots:
       '@effect/platform': 0.91.1(effect@3.18.4)
       '@effect/rpc': 0.71.0(@effect/platform@0.91.1(effect@3.18.4))(effect@3.18.4)
       effect: 3.18.4
+
+  '@effect/workflow@0.11.3(@effect/platform@0.91.1(effect@3.19.6))(@effect/rpc@0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6))(effect@3.19.6)':
+    dependencies:
+      '@effect/platform': 0.91.1(effect@3.19.6)
+      '@effect/rpc': 0.71.0(@effect/platform@0.91.1(effect@3.19.6))(effect@3.19.6)
+      effect: 3.19.6
 
   '@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.18.4))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4))(effect@3.18.4)':
     dependencies:
@@ -8944,6 +9080,11 @@ snapshots:
   ee-first@1.1.1: {}
 
   effect@3.18.4:
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      fast-check: 3.23.2
+
+  effect@3.19.6:
     dependencies:
       '@standard-schema/spec': 1.0.0
       fast-check: 3.23.2


### PR DESCRIPTION
## Summary

- Add `note` CLI package for creating timestamped markdown notes
- Add `@effect-native/schemas` package with reusable slug schema utilities

## What it does

### `note` CLI

A simple command-line tool to create timestamped markdown notes:

```bash
npx note this is my title
# Creates: note-2025-11-26-this-is-my-title.md
```

Features:
- Validates input (rejects flags like `--foo`, filenames like `file.md`, existing files)
- Won't overwrite existing files
- Clean error messages for handled errors

### `@effect-native/schemas`

Reusable Effect Schema definitions:
- `slugify(title)` - convert strings to URL-safe slugs
- `Slug` schema - transforms input to slug
- `SlugBranded` schema - transforms and brands the result

## Testing

- 16 tests in `@effect-native/schemas`
- 24 tests in `note`
- All passing: `pnpm check && pnpm test`

## Known limitations

Schema validation errors from `@effect/cli` still show tree-formatted paths. Awaiting guidance from Effect team on idiomatic approach to override this.