### PR TITLE
fix(ci): use forks pool for crsql tests and fix version in cli test

### DIFF
--- a/packages-native/crsql/vitest.config.ts
+++ b/packages-native/crsql/vitest.config.ts
@@ -14,7 +14,11 @@ process.env.CRSQLITE_PATH ??= LibCrSql.pathToCrSqliteExtension
 const config: ViteUserConfig = {
   test: {
     // Integration tests need longer timeout for nix run commands
-    testTimeout: 30000 // 30 seconds
+    testTimeout: 30000, // 30 seconds
+    // Use forks pool for native module compatibility (crsqlite).
+    // The default threads pool can cause "Channel closed" errors during
+    // cleanup when native modules are loaded.
+    pool: "forks"
   }
 }
 

--- a/packages-native/effect-native/test/cli.test.ts
+++ b/packages-native/effect-native/test/cli.test.ts
@@ -35,7 +35,7 @@ describe("effect-native cli", () => {
 
     const output = lines.join("\n")
 
-    expect(output).toContain("effect-native 0.0.1")
+    expect(output).toContain("effect-native 0.1.0")
     expect(output).toContain("USAGE")
     expect(output).toContain("tight feedback loops")
     expect(output).toContain("Slice time very thinly")


### PR DESCRIPTION
## Summary

- Configure vitest to use `pool: 'forks'` for `@effect-native/crsql` tests. The default `threads` pool causes "Channel closed" errors during cleanup when native modules (crsqlite) are loaded.

- Fix effect-native cli test to expect version `0.1.0` instead of `0.0.1` to match the current package.json version.

## Problem

The release workflow is failing with:

```
Unhandled Rejection Error: Channel closed
❯ target.send node:internal/child_process:753:16
❯ ProcessWorker.send node_modules/.pnpm/tinypool@1.1.1/node_modules/tinypool/dist/index.js:140:41
```

This is a known issue with vitest's default `threads` pool and native modules.

## Solution

Use `pool: 'forks'` which is more stable with native modules per [vitest docs](https://vitest.dev/guide/common-errors.html).