### PR TITLE
Add github-action-scratchpad: Effect-based GitHub Actions toolkit prototype

### DIFF
--- a/.github/workflows/test-github-action-scratchpad.yml
+++ b/.github/workflows/test-github-action-scratchpad.yml
@@ -1,0 +1,28 @@
+name: Test Effect GitHub Action
+
+on:
+  pull_request:
+    branches: ["*"]
+    paths:
+      - "packages-native/github-action-scratchpad/**"
+      - ".github/workflows/test-github-action-scratchpad.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  test-action:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Install dependencies
+        uses: effect-native/effect-native/.github/actions/setup@effect-native/main
+
+      - name: Run Effect GitHub Action
+        uses: ./packages-native/github-action-scratchpad
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-github-action-scratchpad.yml
+++ b/.github/workflows/test-github-action-scratchpad.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "packages-native/github-action-scratchpad/**"
       - ".github/workflows/test-github-action-scratchpad.yml"
+  push:
+    branches:
+      - "tom/github-action-effect"
 
 permissions:
   contents: read

--- a/.github/workflows/test-github-action-scratchpad.yml
+++ b/.github/workflows/test-github-action-scratchpad.yml
@@ -3,12 +3,6 @@ name: Test Effect GitHub Action
 on:
   pull_request:
     branches: ["*"]
-    paths:
-      - "packages-native/github-action-scratchpad/**"
-      - ".github/workflows/test-github-action-scratchpad.yml"
-  push:
-    branches:
-      - "tom/github-action-effect"
 
 permissions:
   contents: read

--- a/.github/workflows/test-github-action-scratchpad.yml
+++ b/.github/workflows/test-github-action-scratchpad.yml
@@ -3,6 +3,7 @@ name: Test Effect GitHub Action
 on:
   pull_request:
     branches: ["*"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/packages-native/github-action-scratchpad/LICENSE
+++ b/packages-native/github-action-scratchpad/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2023 Effectful Technologies Inc (original work)
+Copyright (c) 2025 effect-native contributors (modifications and packages-native/)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/packages-native/github-action-scratchpad/PREP/01-HYPOTHESIS.md
+++ b/packages-native/github-action-scratchpad/PREP/01-HYPOTHESIS.md
@@ -1,0 +1,37 @@
+# Hypothesis: Module Naming
+
+## Prior Assumptions
+
+I expect the following naming pattern to be appropriate:
+
+1. **"Core"** wraps `@actions/core` - the foundational I/O for GitHub Actions
+2. **"GitHub"** wraps `@actions/github` - the context and Octokit client
+
+## Reasoning for Current Names
+
+- `Core` mirrors the npm package name `@actions/core`
+- `GitHub` mirrors the npm package name `@actions/github`
+
+## Problems I Already Suspect
+
+- **"Core"** is extremely generic - could mean anything in any project
+- **"GitHub"** is also generic - GitHub has many APIs, contexts, services
+- Neither name communicates what the module actually DOES
+- These names follow the upstream library names rather than describing the domain concepts
+
+## Expected Better Pattern
+
+Effect packages typically use names that describe:
+- The **domain concept** (what it represents)
+- The **capability** (what it enables)
+- The **service boundary** (what responsibilities it has)
+
+Examples from Effect ecosystem:
+- `@effect/platform` → Platform-specific capabilities
+- `@effect/sql` → SQL database operations
+- `@effect/schema` → Data validation/transformation
+- `@effect/cli` → Command-line interface utilities
+
+## Hypothesis
+
+The module names should describe the **GitHub Actions domain concepts** they wrap, not just mirror the upstream package names.

--- a/packages-native/github-action-scratchpad/PREP/01-WORKING-MODEL.md
+++ b/packages-native/github-action-scratchpad/PREP/01-WORKING-MODEL.md
@@ -1,0 +1,84 @@
+# Working Model: Module Naming
+
+## Updated Understanding
+
+The evidence shows that "Core" and "GitHub" are **package-centric names** not **domain-centric names**. 
+
+The domain is **GitHub Actions Workflows**, and the concepts are:
+
+### Domain Model
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    GitHub Actions Workflow                       │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────────┐    ┌──────────────────────────────────┐  │
+│  │  WorkflowContext │    │           Runner                  │  │
+│  │  ──────────────  │    │           ──────                  │  │
+│  │  • event payload │    │  ┌─────────┐  ┌────────────────┐ │  │
+│  │  • repo info     │    │  │ Inputs  │  │    Outputs     │ │  │
+│  │  • sha, ref      │    │  │ ─────── │  │    ───────     │ │  │
+│  │  • actor         │    │  │ getInput│  │ setOutput      │ │  │
+│  │  • run metadata  │    │  └─────────┘  └────────────────┘ │  │
+│  └──────────────────┘    │                                   │  │
+│                          │  ┌─────────┐  ┌────────────────┐ │  │
+│  ┌──────────────────┐    │  │ Logging │  │  Environment   │ │  │
+│  │   GitHubClient   │    │  │ ─────── │  │  ───────────── │ │  │
+│  │   ────────────   │    │  │ info    │  │ exportVariable │ │  │
+│  │  • Octokit       │    │  │ debug   │  │ addPath        │ │  │
+│  │  • REST API      │    │  │ warning │  │ setSecret      │ │  │
+│  │  • GraphQL       │    │  │ error   │  └────────────────┘ │  │
+│  └──────────────────┘    │  │ group   │                     │  │
+│                          │  └─────────┘  ┌────────────────┐ │  │
+│                          │               │     State      │ │  │
+│                          │               │     ─────      │ │  │
+│                          │               │ saveState      │ │  │
+│                          │               │ getState       │ │  │
+│                          │               └────────────────┘ │  │
+│                          └──────────────────────────────────┘  │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Proposed Module Structure
+
+### Option A: Two Modules (Minimal Change)
+
+| Current | Proposed | Rationale |
+|---------|----------|-----------|
+| `Core` | `Runner` | This module interfaces with the GitHub Actions Runner |
+| `GitHub` | `Workflow` | This module provides workflow context + GitHub API client |
+
+**Pros:** Simple rename, maintains 1:1 mapping with upstream
+**Cons:** Still conflates context and API client
+
+### Option B: Three Modules (Better Separation)
+
+| Module | Responsibility |
+|--------|---------------|
+| `Runner` | Logging, environment, state, lifecycle (setFailed) |
+| `Workflow` | Inputs, outputs, context (payload, repo, sha, actor) |
+| `GitHubClient` | Octokit API client |
+
+**Pros:** Clean separation of concerns
+**Cons:** More modules to import
+
+### Option C: Keep Together, Better Names
+
+| Current | Proposed | Rationale |
+|---------|----------|-----------|
+| `Core` | `Runner` | The runner is what executes the action |
+| `GitHub` | `Context` | The context is what triggered the action |
+
+**Pros:** Simple, descriptive
+**Cons:** "Context" is generic (but less so than "Core" or "GitHub")
+
+## Recommendation: Option A with Caveats
+
+Use **`Runner`** and **`Workflow`**:
+
+- `Runner` - Everything that communicates with the Actions runner
+- `Workflow` - Everything about the workflow execution (context + API)
+
+This is the simplest change that adds real semantic meaning.

--- a/packages-native/github-action-scratchpad/PREP/02-EVIDENCE-LOG.md
+++ b/packages-native/github-action-scratchpad/PREP/02-EVIDENCE-LOG.md
@@ -1,0 +1,84 @@
+# Evidence Log: What Do These Modules Actually Do?
+
+## Module 1: Currently "Core" (wraps @actions/core)
+
+### Functional Responsibilities
+
+| Function | Domain Concept | Category |
+|----------|---------------|----------|
+| `getInput` | Read workflow input parameters | **Workflow I/O** |
+| `getBooleanInput` | Read workflow input parameters | **Workflow I/O** |
+| `getMultilineInput` | Read workflow input parameters | **Workflow I/O** |
+| `setOutput` | Write workflow output values | **Workflow I/O** |
+| `debug`, `info`, `warning`, `error`, `notice` | Emit logs to runner | **Runner Logging** |
+| `startGroup`, `endGroup`, `group` | Collapsible log sections | **Runner Logging** |
+| `exportVariable` | Set environment variables | **Runner Environment** |
+| `addPath` | Modify PATH | **Runner Environment** |
+| `setSecret` | Mask sensitive values | **Runner Security** |
+| `saveState`, `getState` | Persist state between steps | **Step State** |
+| `setFailed` | Set action exit status | **Action Lifecycle** |
+
+### [FALSIFIES] "Core" as a name
+
+- The module is NOT about "core" abstractions
+- It's about **communicating with the GitHub Actions Runner**
+- The runner executes the action, provides inputs, captures outputs
+- This is the **Runner Interface** or **Runner Communication**
+
+### [SUPPORTS] Domain-Specific Name
+
+Possible alternatives:
+- `Runner` - The GitHub Actions runner that executes workflows
+- `Workflow` - The workflow execution context
+- `ActionRunner` - More specific to GitHub Actions
+- `WorkflowIO` - Emphasizes the I/O nature
+
+---
+
+## Module 2: Currently "GitHub" (wraps @actions/github)
+
+### Functional Responsibilities
+
+| Function | Domain Concept | Category |
+|----------|---------------|----------|
+| `context` | Workflow trigger context (event, repo, sha, etc.) | **Workflow Context** |
+| `repo`, `issue`, `sha`, `ref`, `actor` | Specific context properties | **Workflow Context** |
+| `payload` | The webhook event payload | **Event Data** |
+| `getOctokit` | Authenticated GitHub API client | **GitHub API** |
+
+### [FALSIFIES] "GitHub" as a name
+
+- Too broad - GitHub has MANY services (API, OAuth, Packages, etc.)
+- The module has TWO distinct responsibilities:
+  1. Workflow execution context (from environment variables + event payload)
+  2. GitHub REST/GraphQL API client (Octokit)
+- These might actually be **two separate modules**
+
+### [SUPPORTS] Domain-Specific Names
+
+For context:
+- `WorkflowContext` - The context of the running workflow
+- `ActionContext` - The context of the running action
+- `TriggerContext` - What triggered this workflow
+
+For API client:
+- `GitHubApi` - The GitHub API client
+- `Octokit` - Just use the library name
+- `GitHubClient` - API client
+
+---
+
+## Key Finding
+
+The current modules conflate multiple concerns:
+
+1. **"Core"** mixes:
+   - Workflow I/O (inputs/outputs)
+   - Logging
+   - Environment manipulation
+   - State management
+   - Lifecycle control
+
+2. **"GitHub"** mixes:
+   - Workflow context (read-only info about the run)
+   - API client (for making GitHub API calls)

--- a/packages-native/github-action-scratchpad/PREP/03-CONSTANTS.md
+++ b/packages-native/github-action-scratchpad/PREP/03-CONSTANTS.md
@@ -1,0 +1,55 @@
+# Constants: Immutable Constraints
+
+## GitHub Actions Domain Model (Fixed)
+
+These are the "Known Knowns" - facts that constrain our naming:
+
+### 1. GitHub Actions Terminology (Official)
+
+| Term | Definition |
+|------|-----------|
+| **Workflow** | An automated process defined in `.github/workflows/*.yml` |
+| **Job** | A set of steps that execute on the same runner |
+| **Step** | An individual task within a job |
+| **Action** | A reusable unit of code (what we're building) |
+| **Runner** | The server that executes the workflow |
+| **Event** | What triggers the workflow (push, PR, etc.) |
+
+### 2. @actions/core Capabilities (Fixed)
+
+The `@actions/core` package provides:
+- Input/output management
+- Logging and annotations
+- Environment variable manipulation
+- Secret masking
+- State persistence
+- Exit code control
+
+These are ALL **runner communication** mechanisms.
+
+### 3. @actions/github Capabilities (Fixed)
+
+The `@actions/github` package provides:
+- `context` - Workflow execution context
+- `getOctokit()` - Authenticated API client
+
+### 4. Effect Naming Conventions (Observed)
+
+Effect ecosystem patterns:
+- Services named after the **capability** not the wrapper
+- `@effect/platform-node` → Node.js platform capabilities
+- `@effect/sql-pg` → PostgreSQL database access
+- Use nouns for services, verbs for functions
+
+### 5. Package Naming Constraints
+
+The package is `@effect-native/github-action-scratchpad`.
+
+The word "action" is already in the package name, so modules like `ActionRunner` would be redundant.
+
+## Constraints Summary
+
+1. Use official GitHub Actions terminology
+2. Don't duplicate "action" in module names
+3. Names should describe capability, not just wrap a library
+4. Keep it simple - this is a prototype

--- a/packages-native/github-action-scratchpad/PREP/04-STRESS-TEST.md
+++ b/packages-native/github-action-scratchpad/PREP/04-STRESS-TEST.md
@@ -1,0 +1,111 @@
+# Stress Test: Breaking the Name Proposals
+
+## Testing "Runner" (for Core)
+
+### What-If: User confusion with self-hosted runners?
+
+GitHub has "self-hosted runners" and "GitHub-hosted runners" (the VMs).
+
+**Risk:** User might think `Runner` is about *managing* runners, not communicating with the runner their action runs on.
+
+**Verdict:** LOW RISK. The context of "inside an action" makes it clear.
+
+### What-If: Name collision?
+
+```typescript
+import { Runner } from "@effect-native/github-action"
+import { Runner } from "some-other-package" // Conflict!
+```
+
+**Verdict:** MEDIUM RISK. "Runner" is fairly common. Consider:
+- `ActionRunner` (redundant with package name)
+- `WorkflowRunner` (slightly verbose but unique)
+- Keep `Runner` - it's descriptive and unlikely to conflict in action code
+
+### What-If: Future expansion?
+
+What if we add more runner-related features?
+- Job matrix control
+- Step outputs
+- Annotations
+
+**Verdict:** `Runner` is a good umbrella term for all these.
+
+---
+
+## Testing "Workflow" (for GitHub context + API)
+
+### What-If: User wants to create/modify workflows?
+
+They might expect `Workflow` to let them edit `.github/workflows/*.yml` files.
+
+**Risk:** The module only provides *read-only* context, not workflow management.
+
+**Verdict:** HIGH RISK. Misleading name.
+
+### What-If: We split context from API client later?
+
+If we later split `Workflow` into `Context` + `GitHubClient`, the name "Workflow" won't make sense for the API client.
+
+**Verdict:** HIGH RISK. Name doesn't scale.
+
+### Alternative: "Context" instead of "Workflow"
+
+```typescript
+import { Context } from "@effect-native/github-action"
+```
+
+**Problem:** Conflicts with Effect's `Context` module!
+
+```typescript
+import * as Context from "effect/Context" // Core Effect module
+import * as Context from "@effect-native/github-action/Context" // Name collision!
+```
+
+**Verdict:** FATAL RISK. Cannot use "Context" as a module name.
+
+### Alternative: "WorkflowContext"
+
+```typescript
+import { WorkflowContext } from "@effect-native/github-action"
+```
+
+**Verdict:** SAFE. Descriptive, unique, no conflicts.
+
+---
+
+## Testing Three-Module Split
+
+| Module | Contents |
+|--------|----------|
+| `Runner` | Logging, env, state, setFailed |
+| `Inputs` | getInput, setOutput |
+| `WorkflowContext` | context, repo, sha, Octokit |
+
+### What-If: Too many imports?
+
+```typescript
+import * as Runner from "@effect-native/github-action/Runner"
+import * as Inputs from "@effect-native/github-action/Inputs"
+import * as WorkflowContext from "@effect-native/github-action/WorkflowContext"
+```
+
+**Verdict:** MEDIUM RISK. More imports, but cleaner separation.
+
+### What-If: Keep inputs/outputs with context?
+
+Inputs and outputs ARE part of the workflow context (defined in action.yml).
+
+**Verdict:** Inputs/outputs could go in `WorkflowContext`.
+
+---
+
+## Stress Test Results
+
+| Proposal | Risk Level | Issues |
+|----------|------------|--------|
+| `Core` → `Runner` | LOW | Acceptable |
+| `GitHub` → `Workflow` | HIGH | Misleading for workflow editing |
+| `GitHub` → `Context` | FATAL | Conflicts with Effect's Context |
+| `GitHub` → `WorkflowContext` | LOW | Safe and descriptive |
+| Three-module split | MEDIUM | More complexity |

--- a/packages-native/github-action-scratchpad/PREP/05-THEORETICAL-FRAMEWORK.md
+++ b/packages-native/github-action-scratchpad/PREP/05-THEORETICAL-FRAMEWORK.md
@@ -1,0 +1,120 @@
+# Theoretical Framework: Final Naming Proposal
+
+## Effect Platform Naming Pattern
+
+Effect platform packages use a **ludicrously verbose** naming convention:
+
+```
+{Platform} + {Concept} = {PlatformConcept}
+```
+
+Examples from `@effect/platform-bun`:
+- `BunFileSystem`
+- `BunHttpServer`
+- `BunHttpServerRequest`
+- `BunWorkerRunner`
+- `BunCommandExecutor`
+- `BunContext`
+
+Examples from `@effect/platform-node`:
+- `NodeFileSystem`
+- `NodeHttpServer`
+- `NodeHttpClient`
+- `NodeWorkerRunner`
+- `NodeRuntime`
+
+The prefix makes it **ludicrously obvious** what platform you're targeting.
+
+## Applying the Pattern to GitHub Actions
+
+Our platform is **GitHub Actions**, so the prefix should be `GitHubAction`:
+
+```
+GitHubAction + {Concept} = GitHubAction{Concept}
+```
+
+### Module 1: `GitHubActionRunner`
+
+**Wraps:** `@actions/core`
+
+**Rationale:** The GitHub Actions **Runner** is the execution environment. This module provides all communication with the runner:
+- Logging to runner output
+- Reading inputs from runner
+- Writing outputs to runner
+- Setting environment variables
+- Managing state between steps
+- Controlling action exit status
+
+**Service Name:** `GitHubActionRunner` (tag: `@effect-native/github-action/GitHubActionRunner`)
+
+### Module 2: `GitHubActionWorkflowContext`
+
+**Wraps:** `@actions/github` (context portion)
+
+**Rationale:** This module provides the **context** of the current **workflow** execution:
+- What event triggered the workflow
+- Which repository is being acted on
+- The commit SHA, branch/tag ref
+- Who triggered it (actor)
+- Run metadata (runId, runNumber, runAttempt)
+
+**Service Name:** `GitHubActionWorkflowContext` (tag: `@effect-native/github-action/GitHubActionWorkflowContext`)
+
+### Module 3: `GitHubActionClient`
+
+**Wraps:** `@actions/github` (Octokit portion)
+
+**Rationale:** This module provides an authenticated **GitHub API client**:
+- REST API access via Octokit
+- GraphQL API access
+
+**Service Name:** `GitHubActionClient` (tag: `@effect-native/github-action/GitHubActionClient`)
+
+---
+
+## Final Structure
+
+```
+src/
+├── index.ts                        # Re-exports all modules
+├── GitHubActionRunner.ts           # Runner communication (logging, env, state)
+├── GitHubActionWorkflowContext.ts  # Workflow execution context
+└── GitHubActionClient.ts           # GitHub API client (Octokit)
+```
+
+## Usage Example
+
+```typescript
+import * as Effect from "effect/Effect"
+import { 
+  GitHubActionRunner, 
+  GitHubActionWorkflowContext, 
+  GitHubActionClient 
+} from "@effect-native/github-action"
+
+const program = Effect.gen(function* () {
+  // Get workflow context
+  const ctx = yield* GitHubActionWorkflowContext.context
+  
+  // Log to runner
+  yield* GitHubActionRunner.info(`Running in ${ctx.repo.owner}/${ctx.repo.repo}`)
+  
+  // Get inputs
+  const token = yield* GitHubActionRunner.getInput("github-token")
+  
+  // Use GitHub API
+  const octokit = yield* GitHubActionClient.getOctokit(token)
+  const { data: user } = yield* Effect.promise(() => octokit.rest.users.getAuthenticated())
+  
+  // Set output
+  yield* GitHubActionRunner.setOutput("user", user.login)
+})
+```
+
+## Why Verbose Names?
+
+1. **Ludicrously obvious** - No ambiguity about what "Runner" means
+2. **Consistent with Effect ecosystem** - Follows `{Platform}{Concept}` pattern
+3. **Grep-friendly** - `rg "GitHubAction"` finds everything GitHub Actions related
+4. **Self-documenting** - Code reads like English: "GitHubActionRunner.info"
+5. **Future-proof** - If there's ever a `DockerRunner` or `CircleCIRunner`, no confusion

--- a/packages-native/github-action-scratchpad/PREP/06-IMPACT-ASSESSMENT.md
+++ b/packages-native/github-action-scratchpad/PREP/06-IMPACT-ASSESSMENT.md
@@ -1,0 +1,60 @@
+# Impact Assessment: Naming Changes
+
+## Changes Required
+
+| Current | Proposed | Files Affected |
+|---------|----------|----------------|
+| `Core.ts` | `Runner.ts` | 1 source, 1 test, main.ts, index.ts |
+| `GitHub.ts` | `WorkflowContext.ts` + `GitHubClient.ts` | 1 source → 2 sources, main.ts, index.ts |
+
+## Social/Practical Audit
+
+### Will users understand the names?
+
+**Runner** - YES
+- Users already know "GitHub Actions Runner" terminology
+- The name immediately suggests "communication with the runner"
+
+**WorkflowContext** - YES
+- Clear it's about context, not editing workflows
+- "Workflow" scopes it to GitHub Actions
+- Avoids conflict with Effect's Context
+
+**GitHubClient** - YES
+- Standard naming pattern for API clients
+- Clear it's for making GitHub API calls
+
+### Is this a breaking change?
+
+This is a prototype/scratchpad, so no users yet. No breaking change concern.
+
+### Friction Points
+
+1. **Three modules vs two** - More imports, but each import is more focused
+2. **Longer names** - `WorkflowContext` is longer than `GitHub`, but clarity > brevity
+3. **Split API client** - Users must consciously choose when they need the API
+
+### Migration Path (if needed later)
+
+```typescript
+// OLD
+import * as Core from "./Core.js"
+import * as GitHub from "./GitHub.js"
+
+// NEW
+import * as Runner from "./Runner.js"
+import * as WorkflowContext from "./WorkflowContext.js"
+import * as GitHubClient from "./GitHubClient.js"
+```
+
+## Decision
+
+✅ **PROCEED** with the rename:
+- `Core` → `Runner`
+- `GitHub` → `WorkflowContext` + `GitHubClient`
+
+The names are:
+- More descriptive
+- Domain-appropriate  
+- Conflict-free
+- Future-proof

--- a/packages-native/github-action-scratchpad/README.md
+++ b/packages-native/github-action-scratchpad/README.md
@@ -1,0 +1,56 @@
+# @effect-native/github-action-scratchpad
+
+Effect-based GitHub Actions toolkit prototype with no build step.
+
+## Features
+
+- **No build step** - Uses Node.js 24 native TypeScript support
+- **Effect-based API** - Full Effect wrappers for GitHub Actions
+- **Ludicrously obvious naming** - `GitHubActionRunner`, `GitHubActionWorkflowContext`, `GitHubActionClient`
+
+## Modules
+
+### GitHubActionRunner
+
+Communicates with the GitHub Actions Runner:
+- Inputs/outputs (`getInput`, `setOutput`)
+- Logging (`debug`, `info`, `warning`, `error`, `notice`)
+- Groups (`startGroup`, `endGroup`, `group`)
+- Environment (`exportVariable`, `addPath`, `setSecret`)
+- State (`saveState`, `getState`)
+- Lifecycle (`setFailed`)
+
+### GitHubActionWorkflowContext
+
+Provides workflow execution context:
+- Event payload
+- Repository info
+- Commit SHA, ref
+- Actor
+- Run metadata
+
+### GitHubActionClient
+
+GitHub API client (Octokit):
+- `getOctokit(token)` - Get authenticated Octokit instance
+
+## Usage
+
+```typescript
+import * as Effect from "effect/Effect"
+import { 
+  GitHubActionRunner, 
+  GitHubActionWorkflowContext, 
+  GitHubActionClient 
+} from "@effect-native/github-action-scratchpad"
+
+const program = Effect.gen(function* () {
+  const ctx = yield* GitHubActionWorkflowContext.context
+  yield* GitHubActionRunner.info(`Running in ${ctx.repo.owner}/${ctx.repo.repo}`)
+  
+  const token = yield* GitHubActionRunner.getInput("github-token")
+  const octokit = yield* GitHubActionClient.getOctokit(token)
+  
+  yield* GitHubActionRunner.setOutput("result", "success")
+})
+```

--- a/packages-native/github-action-scratchpad/action.yml
+++ b/packages-native/github-action-scratchpad/action.yml
@@ -1,0 +1,25 @@
+name: Effect GitHub Action Scratchpad
+description: Prototype GitHub Action using Effect with native TypeScript (no build step)
+author: effect-native
+
+branding:
+  icon: zap
+  color: purple
+
+inputs:
+  greeting:
+    description: 'A greeting message to display'
+    required: false
+    default: 'Hello from Effect!'
+  who-to-greet:
+    description: 'Who to greet'
+    required: true
+    default: 'World'
+
+outputs:
+  message:
+    description: 'The full greeting message that was displayed'
+
+runs:
+  using: node24
+  main: main.ts

--- a/packages-native/github-action-scratchpad/action.yml
+++ b/packages-native/github-action-scratchpad/action.yml
@@ -7,18 +7,20 @@ branding:
   color: purple
 
 inputs:
-  greeting:
-    description: 'A greeting message to display'
-    required: false
-    default: 'Hello from Effect!'
-  who-to-greet:
-    description: 'Who to greet'
+  github-token:
+    description: 'GitHub token for API access'
     required: true
-    default: 'World'
+    default: ${{ github.token }}
 
 outputs:
-  message:
-    description: 'The full greeting message that was displayed'
+  repo:
+    description: 'The repository (owner/repo)'
+  sha:
+    description: 'The commit SHA'
+  actor:
+    description: 'The actor who triggered the workflow'
+  event:
+    description: 'The event that triggered the workflow'
 
 runs:
   using: node24

--- a/packages-native/github-action-scratchpad/action.yml
+++ b/packages-native/github-action-scratchpad/action.yml
@@ -24,4 +24,4 @@ outputs:
 
 runs:
   using: node24
-  main: main.ts
+  main: run.mjs

--- a/packages-native/github-action-scratchpad/main.ts
+++ b/packages-native/github-action-scratchpad/main.ts
@@ -6,44 +6,105 @@
  */
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
+import * as GitHubActionClient from "./src/GitHubActionClient.js"
 import * as GitHubActionRunner from "./src/GitHubActionRunner.js"
 import * as GitHubActionWorkflowContext from "./src/GitHubActionWorkflowContext.js"
 
 /**
  * The main action logic using Effect
+ *
+ * Demonstrates the full Effect-based GitHub Action toolkit:
+ * - Reading inputs via GitHubActionRunner
+ * - Accessing workflow context via GitHubActionWorkflowContext
+ * - Making API calls via GitHubActionClient (Octokit)
+ * - Structured logging with groups
+ * - Setting outputs
  */
 const program = Effect.gen(function* () {
-  // Get inputs
-  const greeting = yield* GitHubActionRunner.getInput("greeting")
-  const whoToGreet = yield* GitHubActionRunner.getInput("who-to-greet")
+  // Get the GitHub token (required for API calls)
+  const token = yield* GitHubActionRunner.getInput("github-token", { required: true })
 
-  // Get context (will fail gracefully if not in GitHub Actions environment)
-  const contextResult = yield* Effect.either(GitHubActionWorkflowContext.context)
+  // Get workflow context
+  const ctx = yield* GitHubActionWorkflowContext.context
 
-  const contextInfo = contextResult._tag === "Right"
-    ? `Running in ${contextResult.right.repo.owner}/${contextResult.right.repo.repo}`
-    : "Running outside GitHub Actions context"
+  // Get the authenticated Octokit client
+  const octokit = yield* GitHubActionClient.getOctokit(token)
 
-  // Construct the message
-  const message = `${greeting} ${whoToGreet}!`
-
-  // Log with grouping
-  yield* GitHubActionRunner.group("Action Execution", Effect.gen(function* () {
-    yield* GitHubActionRunner.info(`Context: ${contextInfo}`)
-    yield* GitHubActionRunner.info(`Message: ${message}`)
-
-    const debugEnabled = yield* GitHubActionRunner.isDebug
-    if (debugEnabled) {
-      yield* GitHubActionRunner.debug("Debug mode is enabled")
-    }
+  yield* GitHubActionRunner.group("Workflow Context", Effect.gen(function* () {
+    yield* GitHubActionRunner.info(`Event: ${ctx.eventName}`)
+    yield* GitHubActionRunner.info(`Repository: ${ctx.repo.owner}/${ctx.repo.repo}`)
+    yield* GitHubActionRunner.info(`Actor: ${ctx.actor}`)
+    yield* GitHubActionRunner.info(`SHA: ${ctx.sha.substring(0, 7)}`)
+    yield* GitHubActionRunner.info(`Ref: ${ctx.ref}`)
+    yield* GitHubActionRunner.info(`Workflow: ${ctx.workflow}`)
+    yield* GitHubActionRunner.info(`Run ID: ${ctx.runId}`)
+    yield* GitHubActionRunner.info(`Run Number: ${ctx.runNumber}`)
   }))
 
-  // Set output
-  yield* GitHubActionRunner.setOutput("message", message)
+  // Only comment on PRs
+  const prNumber = ctx.payload.pull_request?.number
+  if (prNumber) {
+    yield* GitHubActionRunner.group("Creating PR Comment", Effect.gen(function* () {
+      yield* GitHubActionRunner.info(`PR #${prNumber} detected`)
 
-  yield* GitHubActionRunner.notice(`Action completed successfully: ${message}`)
+      const commentBody = [
+        "## Effect GitHub Action Demo",
+        "",
+        "This comment was created by an Effect-based GitHub Action running **native TypeScript** (no build step!).",
+        "",
+        "### Workflow Context",
+        "",
+        "| Property | Value |",
+        "|----------|-------|",
+        `| Event | \`${ctx.eventName}\` |`,
+        `| Actor | @${ctx.actor} |`,
+        `| SHA | \`${ctx.sha.substring(0, 7)}\` |`,
+        `| Ref | \`${ctx.ref}\` |`,
+        `| Workflow | ${ctx.workflow} |`,
+        `| Run | [#${ctx.runNumber}](${ctx.serverUrl}/${ctx.repo.owner}/${ctx.repo.repo}/actions/runs/${ctx.runId}) |`,
+        "",
+        "### Technical Details",
+        "",
+        "- **Runtime**: Node.js 24 with native TypeScript support",
+        "- **Effect Version**: Using Effect for structured concurrency and dependency injection",
+        "- **Services Used**:",
+        "  - `GitHubActionRunner` - Logging, inputs, outputs",
+        "  - `GitHubActionWorkflowContext` - Workflow metadata",
+        "  - `GitHubActionClient` - Octokit API client",
+        "",
+        "---",
+        `*Timestamp: ${new Date().toISOString()}*`
+      ].join("\n")
 
-  return message
+      // Create the comment using Octokit
+      yield* Effect.tryPromise({
+        try: () =>
+          octokit.rest.issues.createComment({
+            owner: ctx.repo.owner,
+            repo: ctx.repo.repo,
+            issue_number: prNumber,
+            body: commentBody
+          }),
+        catch: (error) => new Error(`Failed to create comment: ${error}`)
+      })
+
+      yield* GitHubActionRunner.info(`Comment created on PR #${prNumber}`)
+    }))
+  } else {
+    yield* GitHubActionRunner.info("Not a PR event, skipping comment creation")
+  }
+
+  // Set outputs
+  yield* GitHubActionRunner.setOutput("repo", `${ctx.repo.owner}/${ctx.repo.repo}`)
+  yield* GitHubActionRunner.setOutput("sha", ctx.sha)
+  yield* GitHubActionRunner.setOutput("actor", ctx.actor)
+  yield* GitHubActionRunner.setOutput("event", ctx.eventName)
+
+  yield* GitHubActionRunner.notice(`Effect GitHub Action completed successfully!`, {
+    title: "Action Complete"
+  })
+
+  return { repo: ctx.repo, sha: ctx.sha, actor: ctx.actor }
 })
 
 /**
@@ -62,7 +123,13 @@ const runAction = program.pipe(
       return undefined as never
     })
   ),
-  Effect.provide(Layer.merge(GitHubActionRunner.layer, GitHubActionWorkflowContext.layer))
+  Effect.provide(
+    Layer.mergeAll(
+      GitHubActionRunner.layer,
+      GitHubActionWorkflowContext.layer,
+      GitHubActionClient.layer
+    )
+  )
 )
 
 // Execute

--- a/packages-native/github-action-scratchpad/main.ts
+++ b/packages-native/github-action-scratchpad/main.ts
@@ -1,0 +1,72 @@
+/**
+ * Main entry point for the GitHub Action
+ *
+ * This file is executed directly by Node.js 24 with native TypeScript support.
+ * No build/bundle step required.
+ */
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as GitHubActionRunner from "./src/GitHubActionRunner.js"
+import * as GitHubActionWorkflowContext from "./src/GitHubActionWorkflowContext.js"
+
+/**
+ * The main action logic using Effect
+ */
+const program = Effect.gen(function* () {
+  // Get inputs
+  const greeting = yield* GitHubActionRunner.getInput("greeting")
+  const whoToGreet = yield* GitHubActionRunner.getInput("who-to-greet")
+
+  // Get context (will fail gracefully if not in GitHub Actions environment)
+  const contextResult = yield* Effect.either(GitHubActionWorkflowContext.context)
+
+  const contextInfo = contextResult._tag === "Right"
+    ? `Running in ${contextResult.right.repo.owner}/${contextResult.right.repo.repo}`
+    : "Running outside GitHub Actions context"
+
+  // Construct the message
+  const message = `${greeting} ${whoToGreet}!`
+
+  // Log with grouping
+  yield* GitHubActionRunner.group("Action Execution", Effect.gen(function* () {
+    yield* GitHubActionRunner.info(`Context: ${contextInfo}`)
+    yield* GitHubActionRunner.info(`Message: ${message}`)
+
+    const debugEnabled = yield* GitHubActionRunner.isDebug
+    if (debugEnabled) {
+      yield* GitHubActionRunner.debug("Debug mode is enabled")
+    }
+  }))
+
+  // Set output
+  yield* GitHubActionRunner.setOutput("message", message)
+
+  yield* GitHubActionRunner.notice(`Action completed successfully: ${message}`)
+
+  return message
+})
+
+/**
+ * Run the action with error handling
+ */
+const runAction = program.pipe(
+  Effect.catchAllDefect((defect) =>
+    Effect.gen(function* () {
+      yield* GitHubActionRunner.setFailed(`Unexpected error: ${String(defect)}`)
+      return undefined as never
+    })
+  ),
+  Effect.catchAll((error) =>
+    Effect.gen(function* () {
+      yield* GitHubActionRunner.setFailed(`Action failed: ${String(error)}`)
+      return undefined as never
+    })
+  ),
+  Effect.provide(Layer.merge(GitHubActionRunner.layer, GitHubActionWorkflowContext.layer))
+)
+
+// Execute
+Effect.runPromise(runAction).catch((error) => {
+  console.error("Fatal error:", error)
+  process.exit(1)
+})

--- a/packages-native/github-action-scratchpad/main.ts
+++ b/packages-native/github-action-scratchpad/main.ts
@@ -6,9 +6,9 @@
  */
 import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
-import * as GitHubActionClient from "./src/GitHubActionClient.js"
-import * as GitHubActionRunner from "./src/GitHubActionRunner.js"
-import * as GitHubActionWorkflowContext from "./src/GitHubActionWorkflowContext.js"
+import * as GitHubActionClient from "./src/GitHubActionClient.ts"
+import * as GitHubActionRunner from "./src/GitHubActionRunner.ts"
+import * as GitHubActionWorkflowContext from "./src/GitHubActionWorkflowContext.ts"
 
 /**
  * The main action logic using Effect

--- a/packages-native/github-action-scratchpad/package.json
+++ b/packages-native/github-action-scratchpad/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@effect-native/github-action-scratchpad",
+  "version": "0.0.1",
+  "type": "module",
+  "license": "MIT",
+  "description": "GitHub Action prototype using Effect with no build step",
+  "homepage": "https://github.com/effect-native/effect-native",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/effect-native/effect-native.git",
+    "directory": "packages-native/github-action-scratchpad"
+  },
+  "bugs": {
+    "url": "https://github.com/effect-native/effect-native/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "directory": "dist",
+    "linkDirectory": false,
+    "tag": "latest"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./internal/*": null
+  },
+  "scripts": {
+    "codegen": "echo '@effect-native/github-action-scratchpad: skip codegen'",
+    "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3",
+    "build-esm": "tsc -b tsconfig.build.json",
+    "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
+    "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest --coverage"
+  },
+  "dependencies": {
+    "@actions/core": "^1.11.1",
+    "@actions/github": "^6.0.1"
+  },
+  "peerDependencies": {
+    "effect": "*"
+  },
+  "devDependencies": {
+    "effect": "latest"
+  }
+}

--- a/packages-native/github-action-scratchpad/run.mjs
+++ b/packages-native/github-action-scratchpad/run.mjs
@@ -1,24 +1,22 @@
 #!/usr/bin/env node
 /**
  * Wrapper script to run main.ts with experimental-transform-types enabled.
- * This allows .js imports to be resolved to .ts files.
+ * This allows Node.js to natively execute TypeScript with .ts imports.
  */
-import { spawn } from "node:child_process"
+import { spawnSync } from "node:child_process"
 import { fileURLToPath } from "node:url"
 import { dirname, join } from "node:path"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const mainTs = join(__dirname, "main.ts")
 
-const child = spawn(
+const result = spawnSync(
   process.execPath,
-  ["--experimental-transform-types", mainTs],
+  ["--experimental-transform-types", "--no-warnings", mainTs],
   {
     stdio: "inherit",
     env: process.env
   }
 )
 
-child.on("exit", (code) => {
-  process.exit(code ?? 0)
-})
+process.exit(result.status ?? 0)

--- a/packages-native/github-action-scratchpad/run.mjs
+++ b/packages-native/github-action-scratchpad/run.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+/**
+ * Wrapper script to run main.ts with experimental-transform-types enabled.
+ * This allows .js imports to be resolved to .ts files.
+ */
+import { spawn } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { dirname, join } from "node:path"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const mainTs = join(__dirname, "main.ts")
+
+const child = spawn(
+  process.execPath,
+  ["--experimental-transform-types", mainTs],
+  {
+    stdio: "inherit",
+    env: process.env
+  }
+)
+
+child.on("exit", (code) => {
+  process.exit(code ?? 0)
+})

--- a/packages-native/github-action-scratchpad/src/GitHubActionClient.ts
+++ b/packages-native/github-action-scratchpad/src/GitHubActionClient.ts
@@ -1,0 +1,61 @@
+/**
+ * GitHubActionClient - Effect wrappers for GitHub API client (Octokit)
+ *
+ * Provides an Effect-based interface for making authenticated GitHub API calls
+ * using Octokit within GitHub Actions.
+ *
+ * @since 0.0.1
+ */
+import * as GHGitHub from "@actions/github"
+import type { GitHub } from "@actions/github/lib/utils.js"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+/**
+ * Authenticated Octokit instance type
+ * @since 0.0.1
+ */
+export type GitHubActionOctokitInstance = InstanceType<typeof GitHub>
+
+/**
+ * GitHub Actions API Client service interface
+ * @since 0.0.1
+ */
+export interface GitHubActionClient {
+  /**
+   * Get an authenticated Octokit client
+   */
+  readonly getOctokit: (token: string) => Effect.Effect<GitHubActionOctokitInstance>
+}
+
+/**
+ * Tag for the GitHubActionClient service
+ * @since 0.0.1
+ */
+export const GitHubActionClient = Context.GenericTag<GitHubActionClient>(
+  "@effect-native/github-action/GitHubActionClient"
+)
+
+/**
+ * Live implementation of GitHubActionClient
+ * @since 0.0.1
+ */
+export const GitHubActionClientLive: GitHubActionClient = {
+  getOctokit: (token) => Effect.sync(() => GHGitHub.getOctokit(token))
+}
+
+/**
+ * Live layer for GitHubActionClient
+ * @since 0.0.1
+ */
+export const layer: Layer.Layer<GitHubActionClient> = Layer.succeed(GitHubActionClient, GitHubActionClientLive)
+
+// --- Accessor functions ---
+
+/**
+ * Get an authenticated Octokit client
+ * @since 0.0.1
+ */
+export const getOctokit = (token: string): Effect.Effect<GitHubActionOctokitInstance, never, GitHubActionClient> =>
+  Effect.flatMap(GitHubActionClient, (client) => client.getOctokit(token))

--- a/packages-native/github-action-scratchpad/src/GitHubActionRunner.ts
+++ b/packages-native/github-action-scratchpad/src/GitHubActionRunner.ts
@@ -1,0 +1,407 @@
+/**
+ * GitHubActionRunner - Effect wrappers for @actions/core
+ *
+ * Provides an Effect-based interface for communicating with the GitHub Actions Runner.
+ * Includes inputs, outputs, logging, annotations, environment, and state management.
+ *
+ * @since 0.0.1
+ */
+import * as GHCore from "@actions/core"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+/**
+ * Input options for getInput
+ * @since 0.0.1
+ */
+export interface GitHubActionInputOptions {
+  /** Whether the input is required. If required and not present, will fail. Defaults to false */
+  readonly required?: boolean
+  /** Whether leading/trailing whitespace will be trimmed. Defaults to true */
+  readonly trimWhitespace?: boolean
+}
+
+/**
+ * Properties for annotations (error, warning, notice)
+ * @since 0.0.1
+ */
+export interface GitHubActionAnnotationProperties {
+  /** A title for the annotation */
+  readonly title?: string
+  /** The path of the file for which the annotation should be created */
+  readonly file?: string
+  /** The start line for the annotation */
+  readonly startLine?: number
+  /** The end line for the annotation */
+  readonly endLine?: number
+  /** The start column for the annotation */
+  readonly startColumn?: number
+  /** The end column for the annotation */
+  readonly endColumn?: number
+}
+
+/**
+ * Error representing a missing required input
+ * @since 0.0.1
+ */
+export class GitHubActionInputRequiredError extends Error {
+  /** @since 0.0.1 */
+  readonly _tag = "GitHubActionInputRequiredError"
+  constructor(readonly name: string) {
+    super(`Input required and not supplied: ${name}`)
+  }
+}
+
+/**
+ * Error representing an invalid boolean input
+ * @since 0.0.1
+ */
+export class GitHubActionInvalidBooleanInputError extends Error {
+  /** @since 0.0.1 */
+  readonly _tag = "GitHubActionInvalidBooleanInputError"
+  constructor(readonly name: string, readonly value: string) {
+    super(
+      `Input does not meet YAML 1.2 "Core Schema" specification: ${name}\n` +
+        `Support boolean input list: \`true | True | TRUE | false | False | FALSE\``
+    )
+  }
+}
+
+/**
+ * GitHub Actions Runner service interface
+ * @since 0.0.1
+ */
+export interface GitHubActionRunner {
+  // --- Inputs/Outputs ---
+  /**
+   * Gets the value of an input. Returns empty string if not defined.
+   */
+  readonly getInput: (name: string, options?: GitHubActionInputOptions) => Effect.Effect<string>
+
+  /**
+   * Gets the values of a multiline input. Each value is trimmed.
+   */
+  readonly getMultilineInput: (name: string, options?: GitHubActionInputOptions) => Effect.Effect<Array<string>>
+
+  /**
+   * Gets a boolean input value. Supports: true|True|TRUE|false|False|FALSE
+   */
+  readonly getBooleanInput: (
+    name: string,
+    options?: GitHubActionInputOptions
+  ) => Effect.Effect<boolean, GitHubActionInvalidBooleanInputError>
+
+  /**
+   * Sets the value of an output.
+   */
+  readonly setOutput: (name: string, value: unknown) => Effect.Effect<void>
+
+  // --- Logging ---
+  /**
+   * Writes debug message to user log
+   */
+  readonly debug: (message: string) => Effect.Effect<void>
+
+  /**
+   * Writes info message to log
+   */
+  readonly info: (message: string) => Effect.Effect<void>
+
+  /**
+   * Adds a warning issue
+   */
+  readonly warning: (message: string, properties?: GitHubActionAnnotationProperties) => Effect.Effect<void>
+
+  /**
+   * Adds an error issue
+   */
+  readonly error: (message: string, properties?: GitHubActionAnnotationProperties) => Effect.Effect<void>
+
+  /**
+   * Adds a notice issue
+   */
+  readonly notice: (message: string, properties?: GitHubActionAnnotationProperties) => Effect.Effect<void>
+
+  /**
+   * Gets whether Actions Step Debug is on
+   */
+  readonly isDebug: Effect.Effect<boolean>
+
+  // --- Groups ---
+  /**
+   * Begin an output group
+   */
+  readonly startGroup: (name: string) => Effect.Effect<void>
+
+  /**
+   * End an output group
+   */
+  readonly endGroup: Effect.Effect<void>
+
+  /**
+   * Wrap an Effect in a collapsible group
+   */
+  readonly group: <A, E, R>(name: string, effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+
+  // --- Environment ---
+  /**
+   * Sets env variable for this action and future actions in the job
+   */
+  readonly exportVariable: (name: string, value: unknown) => Effect.Effect<void>
+
+  /**
+   * Prepends inputPath to the PATH
+   */
+  readonly addPath: (inputPath: string) => Effect.Effect<void>
+
+  /**
+   * Registers a secret which will get masked from logs
+   */
+  readonly setSecret: (secret: string) => Effect.Effect<void>
+
+  // --- State ---
+  /**
+   * Saves state for current action's post job execution
+   */
+  readonly saveState: (name: string, value: unknown) => Effect.Effect<void>
+
+  /**
+   * Gets the value of state set by this action's main execution
+   */
+  readonly getState: (name: string) => Effect.Effect<string>
+
+  // --- Results ---
+  /**
+   * Sets the action status to failed. Calling this will cause the action
+   * to exit with a failure status code.
+   */
+  readonly setFailed: (message: string) => Effect.Effect<void>
+}
+
+/**
+ * Tag for the GitHubActionRunner service
+ * @since 0.0.1
+ */
+export const GitHubActionRunner = Context.GenericTag<GitHubActionRunner>(
+  "@effect-native/github-action/GitHubActionRunner"
+)
+
+/**
+ * Live implementation of GitHubActionRunner using @actions/core
+ * @since 0.0.1
+ */
+export const GitHubActionRunnerLive: GitHubActionRunner = {
+  getInput: (name, options) => Effect.sync(() => GHCore.getInput(name, options)),
+
+  getMultilineInput: (name, options) => Effect.sync(() => GHCore.getMultilineInput(name, options)),
+
+  getBooleanInput: (name, options) =>
+    Effect.try({
+      try: () => GHCore.getBooleanInput(name, options),
+      catch: () => new GitHubActionInvalidBooleanInputError(name, GHCore.getInput(name, options))
+    }),
+
+  setOutput: (name, value) => Effect.sync(() => GHCore.setOutput(name, value)),
+
+  debug: (message) => Effect.sync(() => GHCore.debug(message)),
+
+  info: (message) => Effect.sync(() => GHCore.info(message)),
+
+  warning: (message, properties) => Effect.sync(() => GHCore.warning(message, properties)),
+
+  error: (message, properties) => Effect.sync(() => GHCore.error(message, properties)),
+
+  notice: (message, properties) => Effect.sync(() => GHCore.notice(message, properties)),
+
+  isDebug: Effect.sync(() => GHCore.isDebug()),
+
+  startGroup: (name) => Effect.sync(() => GHCore.startGroup(name)),
+
+  endGroup: Effect.sync(() => GHCore.endGroup()),
+
+  group: (name, effect) =>
+    Effect.acquireUseRelease(
+      Effect.sync(() => GHCore.startGroup(name)),
+      () => effect,
+      () => Effect.sync(() => GHCore.endGroup())
+    ),
+
+  exportVariable: (name, value) => Effect.sync(() => GHCore.exportVariable(name, value)),
+
+  addPath: (inputPath) => Effect.sync(() => GHCore.addPath(inputPath)),
+
+  setSecret: (secret) => Effect.sync(() => GHCore.setSecret(secret)),
+
+  saveState: (name, value) => Effect.sync(() => GHCore.saveState(name, value)),
+
+  getState: (name) => Effect.sync(() => GHCore.getState(name)),
+
+  setFailed: (message) => Effect.sync(() => GHCore.setFailed(message))
+}
+
+/**
+ * Live layer for GitHubActionRunner
+ * @since 0.0.1
+ */
+export const layer: Layer.Layer<GitHubActionRunner> = Layer.succeed(GitHubActionRunner, GitHubActionRunnerLive)
+
+// --- Accessor functions ---
+
+/**
+ * Gets the value of an input
+ * @since 0.0.1
+ */
+export const getInput = (
+  name: string,
+  options?: GitHubActionInputOptions
+): Effect.Effect<string, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.getInput(name, options))
+
+/**
+ * Gets the values of a multiline input
+ * @since 0.0.1
+ */
+export const getMultilineInput = (
+  name: string,
+  options?: GitHubActionInputOptions
+): Effect.Effect<Array<string>, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.getMultilineInput(name, options))
+
+/**
+ * Gets a boolean input value
+ * @since 0.0.1
+ */
+export const getBooleanInput = (
+  name: string,
+  options?: GitHubActionInputOptions
+): Effect.Effect<boolean, GitHubActionInvalidBooleanInputError, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.getBooleanInput(name, options))
+
+/**
+ * Sets the value of an output
+ * @since 0.0.1
+ */
+export const setOutput = (name: string, value: unknown): Effect.Effect<void, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.setOutput(name, value))
+
+/**
+ * Writes debug message to user log
+ * @since 0.0.1
+ */
+export const debug = (message: string): Effect.Effect<void, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.debug(message))
+
+/**
+ * Writes info message to log
+ * @since 0.0.1
+ */
+export const info = (message: string): Effect.Effect<void, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.info(message))
+
+/**
+ * Adds a warning issue
+ * @since 0.0.1
+ */
+export const warning = (
+  message: string,
+  properties?: GitHubActionAnnotationProperties
+): Effect.Effect<void, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.warning(message, properties))
+
+/**
+ * Adds an error issue
+ * @since 0.0.1
+ */
+export const error = (
+  message: string,
+  properties?: GitHubActionAnnotationProperties
+): Effect.Effect<void, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.error(message, properties))
+
+/**
+ * Adds a notice issue
+ * @since 0.0.1
+ */
+export const notice = (
+  message: string,
+  properties?: GitHubActionAnnotationProperties
+): Effect.Effect<void, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.notice(message, properties))
+
+/**
+ * Gets whether Actions Step Debug is on
+ * @since 0.0.1
+ */
+export const isDebug: Effect.Effect<boolean, never, GitHubActionRunner> = Effect.flatMap(
+  GitHubActionRunner,
+  (runner) => runner.isDebug
+)
+
+/**
+ * Begin an output group
+ * @since 0.0.1
+ */
+export const startGroup = (name: string): Effect.Effect<void, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.startGroup(name))
+
+/**
+ * End an output group
+ * @since 0.0.1
+ */
+export const endGroup: Effect.Effect<void, never, GitHubActionRunner> = Effect.flatMap(
+  GitHubActionRunner,
+  (runner) => runner.endGroup
+)
+
+/**
+ * Wrap an Effect in a collapsible group
+ * @since 0.0.1
+ */
+export const group = <A, E, R>(
+  name: string,
+  effect: Effect.Effect<A, E, R>
+): Effect.Effect<A, E, GitHubActionRunner | R> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.group(name, effect))
+
+/**
+ * Sets env variable for this action and future actions in the job
+ * @since 0.0.1
+ */
+export const exportVariable = (name: string, value: unknown): Effect.Effect<void, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.exportVariable(name, value))
+
+/**
+ * Prepends inputPath to the PATH
+ * @since 0.0.1
+ */
+export const addPath = (inputPath: string): Effect.Effect<void, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.addPath(inputPath))
+
+/**
+ * Registers a secret which will get masked from logs
+ * @since 0.0.1
+ */
+export const setSecret = (secret: string): Effect.Effect<void, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.setSecret(secret))
+
+/**
+ * Saves state for current action's post job execution
+ * @since 0.0.1
+ */
+export const saveState = (name: string, value: unknown): Effect.Effect<void, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.saveState(name, value))
+
+/**
+ * Gets the value of state set by this action's main execution
+ * @since 0.0.1
+ */
+export const getState = (name: string): Effect.Effect<string, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.getState(name))
+
+/**
+ * Sets the action status to failed
+ * @since 0.0.1
+ */
+export const setFailed = (message: string): Effect.Effect<void, never, GitHubActionRunner> =>
+  Effect.flatMap(GitHubActionRunner, (runner) => runner.setFailed(message))

--- a/packages-native/github-action-scratchpad/src/GitHubActionWorkflowContext.ts
+++ b/packages-native/github-action-scratchpad/src/GitHubActionWorkflowContext.ts
@@ -1,0 +1,280 @@
+/**
+ * GitHubActionWorkflowContext - Effect wrappers for GitHub Actions workflow context
+ *
+ * Provides an Effect-based interface for accessing the GitHub Actions workflow
+ * execution context including event payload, repository info, and run metadata.
+ *
+ * @since 0.0.1
+ */
+import * as GHGitHub from "@actions/github"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+
+/**
+ * Webhook payload type
+ * @since 0.0.1
+ */
+export interface GitHubActionWebhookPayload {
+  readonly [key: string]: unknown
+  readonly repository?: {
+    readonly owner: { readonly login: string; readonly [key: string]: unknown }
+    readonly name: string
+    readonly [key: string]: unknown
+  }
+  readonly issue?: { readonly number: number; readonly [key: string]: unknown }
+  readonly pull_request?: { readonly number: number; readonly [key: string]: unknown }
+  readonly sender?: { readonly type?: string; readonly login?: string; readonly [key: string]: unknown }
+  readonly action?: string
+  readonly number?: number
+}
+
+/**
+ * Repository reference
+ * @since 0.0.1
+ */
+export interface GitHubActionRepoRef {
+  readonly owner: string
+  readonly repo: string
+}
+
+/**
+ * Issue/PR reference
+ * @since 0.0.1
+ */
+export interface GitHubActionIssueRef extends GitHubActionRepoRef {
+  readonly number: number
+}
+
+/**
+ * GitHub Actions workflow context data
+ * @since 0.0.1
+ */
+export interface GitHubActionWorkflowContextData {
+  /** Webhook payload object that triggered the workflow */
+  readonly payload: GitHubActionWebhookPayload
+  /** Name of the event that triggered the workflow */
+  readonly eventName: string
+  /** SHA of the commit that triggered the workflow */
+  readonly sha: string
+  /** Git ref (branch or tag) that triggered the workflow */
+  readonly ref: string
+  /** Name of the workflow */
+  readonly workflow: string
+  /** Name of the action */
+  readonly action: string
+  /** Login of the actor who triggered the workflow */
+  readonly actor: string
+  /** Name of the job */
+  readonly job: string
+  /** Run attempt number */
+  readonly runAttempt: number
+  /** Run number */
+  readonly runNumber: number
+  /** Unique identifier of the run */
+  readonly runId: number
+  /** GitHub API URL */
+  readonly apiUrl: string
+  /** GitHub server URL */
+  readonly serverUrl: string
+  /** GitHub GraphQL API URL */
+  readonly graphqlUrl: string
+  /** Repository owner and name */
+  readonly repo: GitHubActionRepoRef
+  /** Issue/PR reference (if applicable) */
+  readonly issue: GitHubActionIssueRef
+}
+
+/**
+ * Error when repository context is not available
+ * @since 0.0.1
+ */
+export class GitHubActionRepoContextError extends Error {
+  /** @since 0.0.1 */
+  readonly _tag = "GitHubActionRepoContextError"
+  constructor() {
+    super("context.repo requires a GITHUB_REPOSITORY environment variable like 'owner/repo'")
+  }
+}
+
+/**
+ * GitHub Actions Workflow Context service interface
+ * @since 0.0.1
+ */
+export interface GitHubActionWorkflowContext {
+  /**
+   * Get the full workflow context
+   */
+  readonly context: Effect.Effect<GitHubActionWorkflowContextData, GitHubActionRepoContextError>
+}
+
+/**
+ * Tag for the GitHubActionWorkflowContext service
+ * @since 0.0.1
+ */
+export const GitHubActionWorkflowContext = Context.GenericTag<GitHubActionWorkflowContext>(
+  "@effect-native/github-action/GitHubActionWorkflowContext"
+)
+
+/**
+ * Convert the raw context to our typed context data
+ */
+const getContextData = (): Effect.Effect<GitHubActionWorkflowContextData, GitHubActionRepoContextError> =>
+  Effect.try({
+    try: () => {
+      const ctx = GHGitHub.context
+      return {
+        payload: ctx.payload as GitHubActionWebhookPayload,
+        eventName: ctx.eventName,
+        sha: ctx.sha,
+        ref: ctx.ref,
+        workflow: ctx.workflow,
+        action: ctx.action,
+        actor: ctx.actor,
+        job: ctx.job,
+        runAttempt: ctx.runAttempt,
+        runNumber: ctx.runNumber,
+        runId: ctx.runId,
+        apiUrl: ctx.apiUrl,
+        serverUrl: ctx.serverUrl,
+        graphqlUrl: ctx.graphqlUrl,
+        repo: ctx.repo,
+        issue: ctx.issue
+      }
+    },
+    catch: () => new GitHubActionRepoContextError()
+  })
+
+/**
+ * Live implementation of GitHubActionWorkflowContext
+ * @since 0.0.1
+ */
+export const GitHubActionWorkflowContextLive: GitHubActionWorkflowContext = {
+  context: getContextData()
+}
+
+/**
+ * Live layer for GitHubActionWorkflowContext
+ * @since 0.0.1
+ */
+export const layer: Layer.Layer<GitHubActionWorkflowContext> = Layer.succeed(
+  GitHubActionWorkflowContext,
+  GitHubActionWorkflowContextLive
+)
+
+// --- Accessor functions ---
+
+/**
+ * Get the full workflow context
+ * @since 0.0.1
+ */
+export const context: Effect.Effect<
+  GitHubActionWorkflowContextData,
+  GitHubActionRepoContextError,
+  GitHubActionWorkflowContext
+> = Effect.flatMap(GitHubActionWorkflowContext, (ctx) => ctx.context)
+
+/**
+ * Get the webhook payload
+ * @since 0.0.1
+ */
+export const payload: Effect.Effect<
+  GitHubActionWebhookPayload,
+  GitHubActionRepoContextError,
+  GitHubActionWorkflowContext
+> = Effect.map(context, (ctx) => ctx.payload)
+
+/**
+ * Get the event name
+ * @since 0.0.1
+ */
+export const eventName: Effect.Effect<string, GitHubActionRepoContextError, GitHubActionWorkflowContext> = Effect.map(
+  context,
+  (ctx) => ctx.eventName
+)
+
+/**
+ * Get the repository reference
+ * @since 0.0.1
+ */
+export const repo: Effect.Effect<GitHubActionRepoRef, GitHubActionRepoContextError, GitHubActionWorkflowContext> =
+  Effect.map(context, (ctx) => ctx.repo)
+
+/**
+ * Get the issue/PR reference
+ * @since 0.0.1
+ */
+export const issue: Effect.Effect<GitHubActionIssueRef, GitHubActionRepoContextError, GitHubActionWorkflowContext> =
+  Effect.map(context, (ctx) => ctx.issue)
+
+/**
+ * Get the commit SHA
+ * @since 0.0.1
+ */
+export const sha: Effect.Effect<string, GitHubActionRepoContextError, GitHubActionWorkflowContext> = Effect.map(
+  context,
+  (ctx) => ctx.sha
+)
+
+/**
+ * Get the git ref (branch/tag)
+ * @since 0.0.1
+ */
+export const ref: Effect.Effect<string, GitHubActionRepoContextError, GitHubActionWorkflowContext> = Effect.map(
+  context,
+  (ctx) => ctx.ref
+)
+
+/**
+ * Get the actor who triggered the workflow
+ * @since 0.0.1
+ */
+export const actor: Effect.Effect<string, GitHubActionRepoContextError, GitHubActionWorkflowContext> = Effect.map(
+  context,
+  (ctx) => ctx.actor
+)
+
+/**
+ * Get the workflow name
+ * @since 0.0.1
+ */
+export const workflow: Effect.Effect<string, GitHubActionRepoContextError, GitHubActionWorkflowContext> = Effect.map(
+  context,
+  (ctx) => ctx.workflow
+)
+
+/**
+ * Get the job name
+ * @since 0.0.1
+ */
+export const job: Effect.Effect<string, GitHubActionRepoContextError, GitHubActionWorkflowContext> = Effect.map(
+  context,
+  (ctx) => ctx.job
+)
+
+/**
+ * Get the run ID
+ * @since 0.0.1
+ */
+export const runId: Effect.Effect<number, GitHubActionRepoContextError, GitHubActionWorkflowContext> = Effect.map(
+  context,
+  (ctx) => ctx.runId
+)
+
+/**
+ * Get the run number
+ * @since 0.0.1
+ */
+export const runNumber: Effect.Effect<number, GitHubActionRepoContextError, GitHubActionWorkflowContext> = Effect.map(
+  context,
+  (ctx) => ctx.runNumber
+)
+
+/**
+ * Get the run attempt number
+ * @since 0.0.1
+ */
+export const runAttempt: Effect.Effect<number, GitHubActionRepoContextError, GitHubActionWorkflowContext> = Effect.map(
+  context,
+  (ctx) => ctx.runAttempt
+)

--- a/packages-native/github-action-scratchpad/src/index.ts
+++ b/packages-native/github-action-scratchpad/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @effect-native/github-action-scratchpad
+ *
+ * Effect-based GitHub Actions toolkit - prototype with no build step
+ *
+ * @since 0.0.1
+ */
+
+/**
+ * GitHubActionRunner - Runner communication (logging, env, state, inputs/outputs)
+ * @since 0.0.1
+ */
+export * as GitHubActionRunner from "./GitHubActionRunner.js"
+
+/**
+ * GitHubActionWorkflowContext - Workflow execution context (event, repo, sha, actor)
+ * @since 0.0.1
+ */
+export * as GitHubActionWorkflowContext from "./GitHubActionWorkflowContext.js"
+
+/**
+ * GitHubActionClient - GitHub API client (Octokit)
+ * @since 0.0.1
+ */
+export * as GitHubActionClient from "./GitHubActionClient.js"

--- a/packages-native/github-action-scratchpad/test/GitHubActionRunner.test.ts
+++ b/packages-native/github-action-scratchpad/test/GitHubActionRunner.test.ts
@@ -1,0 +1,139 @@
+import { describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import * as GitHubActionRunner from "../src/GitHubActionRunner.js"
+
+/**
+ * Mock implementation of GitHubActionRunner for testing
+ */
+const mockInputs = new Map<string, string>([
+  ["greeting", "Hello"],
+  ["who-to-greet", "World"],
+  ["enabled", "true"]
+])
+
+const mockOutputs = new Map<string, unknown>()
+const logs: Array<{ level: string; message: string }> = []
+
+const MockGitHubActionRunner: GitHubActionRunner.GitHubActionRunner = {
+  getInput: (name) => Effect.sync(() => mockInputs.get(name) ?? ""),
+
+  getMultilineInput: (name) =>
+    Effect.sync(() => {
+      const value = mockInputs.get(name) ?? ""
+      return value.split("\n").filter((x) => x !== "")
+    }),
+
+  getBooleanInput: (name) =>
+    Effect.try({
+      try: () => {
+        const val = mockInputs.get(name) ?? ""
+        if (["true", "True", "TRUE"].includes(val)) return true
+        if (["false", "False", "FALSE"].includes(val)) return false
+        throw new Error(`Invalid boolean: ${val}`)
+      },
+      catch: () => new GitHubActionRunner.GitHubActionInvalidBooleanInputError(name, mockInputs.get(name) ?? "")
+    }),
+
+  setOutput: (name, value) =>
+    Effect.sync(() => {
+      mockOutputs.set(name, value)
+    }),
+
+  debug: (message) =>
+    Effect.sync(() => {
+      logs.push({ level: "debug", message })
+    }),
+
+  info: (message) =>
+    Effect.sync(() => {
+      logs.push({ level: "info", message })
+    }),
+
+  warning: (message) =>
+    Effect.sync(() => {
+      logs.push({ level: "warning", message })
+    }),
+
+  error: (message) =>
+    Effect.sync(() => {
+      logs.push({ level: "error", message })
+    }),
+
+  notice: (message) =>
+    Effect.sync(() => {
+      logs.push({ level: "notice", message })
+    }),
+
+  isDebug: Effect.succeed(false),
+
+  startGroup: () => Effect.void,
+
+  endGroup: Effect.void,
+
+  group: (_name, effect) => effect,
+
+  exportVariable: () => Effect.void,
+
+  addPath: () => Effect.void,
+
+  setSecret: () => Effect.void,
+
+  saveState: () => Effect.void,
+
+  getState: () => Effect.succeed(""),
+
+  setFailed: (message) =>
+    Effect.sync(() => {
+      logs.push({ level: "failed", message })
+    })
+}
+
+const MockGitHubActionRunnerLayer = Layer.succeed(GitHubActionRunner.GitHubActionRunner, MockGitHubActionRunner)
+
+describe("GitHubActionRunner", () => {
+  it.effect("getInput returns the input value", () =>
+    Effect.gen(function*() {
+      const result = yield* GitHubActionRunner.getInput("greeting")
+      return result === "Hello"
+    }).pipe(
+      Effect.provide(MockGitHubActionRunnerLayer),
+      Effect.map((result) => {
+        if (!result) throw new Error("Expected greeting to be 'Hello'")
+      })
+    ))
+
+  it.effect("getBooleanInput returns true for 'true'", () =>
+    Effect.gen(function*() {
+      const result = yield* GitHubActionRunner.getBooleanInput("enabled")
+      return result === true
+    }).pipe(
+      Effect.provide(MockGitHubActionRunnerLayer),
+      Effect.map((result) => {
+        if (!result) throw new Error("Expected enabled to be true")
+      })
+    ))
+
+  it.effect("setOutput stores the value", () =>
+    Effect.gen(function*() {
+      yield* GitHubActionRunner.setOutput("message", "Hello World!")
+      return mockOutputs.get("message") === "Hello World!"
+    }).pipe(
+      Effect.provide(MockGitHubActionRunnerLayer),
+      Effect.map((result) => {
+        if (!result) throw new Error("Expected output to be set")
+      })
+    ))
+
+  it.effect("info logs a message", () =>
+    Effect.gen(function*() {
+      logs.length = 0
+      yield* GitHubActionRunner.info("Test message")
+      return logs.some((log) => log.level === "info" && log.message === "Test message")
+    }).pipe(
+      Effect.provide(MockGitHubActionRunnerLayer),
+      Effect.map((result) => {
+        if (!result) throw new Error("Expected info log")
+      })
+    ))
+})

--- a/packages-native/github-action-scratchpad/tsconfig.action.json
+++ b/packages-native/github-action-scratchpad/tsconfig.action.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["main.ts", "src"],
+  "compilerOptions": {
+    "types": ["node"],
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true
+  }
+}

--- a/packages-native/github-action-scratchpad/tsconfig.build.json
+++ b/packages-native/github-action-scratchpad/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.src.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "tsBuildInfoFile": ".tsbuildinfo/build.tsbuildinfo",
+    "outDir": "build/esm",
+    "declarationDir": "build/dts",
+    "stripInternal": true
+  }
+}

--- a/packages-native/github-action-scratchpad/tsconfig.json
+++ b/packages-native/github-action-scratchpad/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [],
+  "references": [
+    { "path": "tsconfig.src.json" },
+    { "path": "tsconfig.test.json" }
+  ]
+}

--- a/packages-native/github-action-scratchpad/tsconfig.src.json
+++ b/packages-native/github-action-scratchpad/tsconfig.src.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "main.ts"],
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "build/src",
+    "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
+    "rootDir": "."
+  }
+}

--- a/packages-native/github-action-scratchpad/tsconfig.src.json
+++ b/packages-native/github-action-scratchpad/tsconfig.src.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src", "main.ts"],
+  "include": ["src"],
   "compilerOptions": {
     "types": ["node"],
     "outDir": "build/src",
     "tsBuildInfoFile": ".tsbuildinfo/src.tsbuildinfo",
-    "rootDir": "."
+    "rootDir": "src"
   }
 }

--- a/packages-native/github-action-scratchpad/tsconfig.test.json
+++ b/packages-native/github-action-scratchpad/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["test"],
+  "references": [
+    { "path": "tsconfig.src.json" }
+  ],
+  "compilerOptions": {
+    "types": ["node"],
+    "tsBuildInfoFile": ".tsbuildinfo/test.tsbuildinfo",
+    "rootDir": "test",
+    "outDir": "build/test"
+  }
+}

--- a/packages-native/github-action-scratchpad/vitest.config.ts
+++ b/packages-native/github-action-scratchpad/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from "vitest/config"
+import shared from "../../vitest.shared"
+
+export default defineConfig(shared)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,19 @@ importers:
         version: 3.18.4
     publishDirectory: dist
 
+  packages-native/github-action-scratchpad:
+    dependencies:
+      '@actions/core':
+        specifier: ^1.11.1
+        version: 1.11.1
+      '@actions/github':
+        specifier: ^6.0.1
+        version: 6.0.1
+      effect:
+        specifier: latest
+        version: 3.19.6
+    publishDirectory: dist
+
   packages-native/libcrsql:
     dependencies:
       '@effect/platform':
@@ -425,6 +438,21 @@ importers:
         version: 3.18.4
 
 packages:
+
+  '@actions/core@1.11.1':
+    resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
+
+  '@actions/exec@1.1.1':
+    resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
+
+  '@actions/github@6.0.1':
+    resolution: {integrity: sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==}
+
+  '@actions/http-client@2.2.3':
+    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
+
+  '@actions/io@1.1.3':
+    resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1521,6 +1549,10 @@ packages:
     resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1727,6 +1759,54 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@octokit/auth-token@4.0.0':
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/core@5.2.2':
+    resolution: {integrity: sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==}
+    engines: {node: '>= 18'}
+
+  '@octokit/endpoint@9.0.6':
+    resolution: {integrity: sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/graphql@7.1.1':
+    resolution: {integrity: sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/openapi-types@20.0.0':
+    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
+
+  '@octokit/openapi-types@24.2.0':
+    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
+
+  '@octokit/plugin-paginate-rest@9.2.2':
+    resolution: {integrity: sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/plugin-rest-endpoint-methods@10.4.1':
+    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/request-error@5.1.1':
+    resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/request@8.4.1':
+    resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/types@12.6.0':
+    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
+
+  '@octokit/types@13.10.0':
+    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
   '@op-engineering/op-sqlite@7.1.0':
     resolution: {integrity: sha512-tF+YLwAyV/52r7k3BCFRareiTIzR2bGVQbW54/zJgyL+lzoGJ7bHTGBauXGJAPIYKLxGq0zFxI4HbfzsNQOWgg==}
@@ -2619,6 +2699,9 @@ packages:
     resolution: {integrity: sha512-GM9c0cWWR8Ga7//Ves/9KRgTS8nLausCkP3CGiFLrnwA2CDUluXgaQqvrULoR2Ujrd/mz/lkX87F5BHFsNr5sQ==}
     hasBin: true
 
+  before-after-hook@2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -2959,6 +3042,9 @@ packages:
     resolution: {integrity: sha512-dwc59FRIsht+HfnTVM0BCjJaEWxdq2YAvEDy4/Hn6CwS3CBWMtFnL3aZGAkQn3XCYxk/YcTDE4jX2Q7bFTwCjA==}
     engines: {node: '>=14'}
     hasBin: true
+
+  deprecation@2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -5602,6 +5688,10 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -5656,12 +5746,19 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
   undici@7.16.0:
     resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
     engines: {node: '>=20.18.1'}
 
   unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
+
+  universal-user-agent@6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -5930,6 +6027,32 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@actions/core@1.11.1':
+    dependencies:
+      '@actions/exec': 1.1.1
+      '@actions/http-client': 2.2.3
+
+  '@actions/exec@1.1.1':
+    dependencies:
+      '@actions/io': 1.1.3
+
+  '@actions/github@6.0.1':
+    dependencies:
+      '@actions/http-client': 2.2.3
+      '@octokit/core': 5.2.2
+      '@octokit/plugin-paginate-rest': 9.2.2(@octokit/core@5.2.2)
+      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.2)
+      '@octokit/request': 8.4.1
+      '@octokit/request-error': 5.1.1
+      undici: 5.29.0
+
+  '@actions/http-client@2.2.3':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 5.29.0
+
+  '@actions/io@1.1.3': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -7409,6 +7532,8 @@ snapshots:
       '@eslint/core': 0.16.0
       levn: 0.4.1
 
+  '@fastify/busboy@2.1.1': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -7650,6 +7775,64 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@octokit/auth-token@4.0.0': {}
+
+  '@octokit/core@5.2.2':
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.1.1
+      '@octokit/request': 8.4.1
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.1
+
+  '@octokit/endpoint@9.0.6':
+    dependencies:
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/graphql@7.1.1':
+    dependencies:
+      '@octokit/request': 8.4.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/openapi-types@20.0.0': {}
+
+  '@octokit/openapi-types@24.2.0': {}
+
+  '@octokit/plugin-paginate-rest@9.2.2(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/types': 12.6.0
+
+  '@octokit/plugin-rest-endpoint-methods@10.4.1(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/types': 12.6.0
+
+  '@octokit/request-error@5.1.1':
+    dependencies:
+      '@octokit/types': 13.10.0
+      deprecation: 2.3.1
+      once: 1.4.0
+
+  '@octokit/request@8.4.1':
+    dependencies:
+      '@octokit/endpoint': 9.0.6
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/types@12.6.0':
+    dependencies:
+      '@octokit/openapi-types': 20.0.0
+
+  '@octokit/types@13.10.0':
+    dependencies:
+      '@octokit/openapi-types': 24.2.0
 
   '@op-engineering/op-sqlite@7.1.0(react-native@0.82.0(@babel/core@7.28.4)(@types/react@19.2.2)(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -8577,6 +8760,8 @@ snapshots:
 
   baseline-browser-mapping@2.8.14: {}
 
+  before-after-hook@2.2.3: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -8960,6 +9145,8 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  deprecation@2.3.1: {}
 
   dequal@2.0.3: {}
 
@@ -11929,6 +12116,8 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  tunnel@0.0.6: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -11989,11 +12178,17 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
   undici@7.16.0: {}
 
   unist-util-stringify-position@2.0.3:
     dependencies:
       '@types/unist': 2.0.11
+
+  universal-user-agent@6.0.1: {}
 
   universalify@0.1.2: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "include": [],
   "references": [
     { "path": "packages-native/bun-test" },
+    { "path": "packages-native/github-action-scratchpad" },
     { "path": "packages-native/patterns" }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `@effect-native/github-action-scratchpad` package - Effect-based GitHub Actions toolkit prototype
- **No build step required** - Uses Node.js 24 native TypeScript support
- Following Effect platform naming convention (`GitHubAction{Concept}`)

## Modules

| Module | Purpose |
|--------|---------|
| `GitHubActionRunner` | Runner communication (logging, env, state, inputs/outputs) |
| `GitHubActionWorkflowContext` | Workflow execution context (event, repo, sha, actor) |
| `GitHubActionClient` | GitHub API client (Octokit) |

## Testing

- Type check: PASS
- Tests: 4/4 PASS  
- Lint: PASS
- Build: PASS

## Next Steps

Once CI passes, we can test the action by using it in a workflow.