### PR TITLE
Fix: remove branches filter from pull_request trigger

### DIFF
--- a/.github/workflows/test-github-action-scratchpad.yml
+++ b/.github/workflows/test-github-action-scratchpad.yml
@@ -2,7 +2,6 @@ name: Test Effect GitHub Action
 
 on:
   pull_request:
-    branches: ["*"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The branches filter was preventing the workflow from triggering on pull requests.