### PR TITLE
fix(note): rewrite imports in dist/bin.mjs to correct paths

### DIFF
--- a/packages-native/note/scripts/copy-bin.mjs
+++ b/packages-native/note/scripts/copy-bin.mjs
@@ -14,6 +14,12 @@ try {
   throw new Error(`note: expected ESM build at ${source}`, { cause: error })
 }
 
+// Rewrite relative imports to point to dist/esm/ since bin.mjs is at package root
+content = content.replace(
+  /from "\.\/([A-Z][^"]+\.js)"/g,
+  "from \"./dist/esm/$1\""
+)
+
 await mkdir(dirname(target), { recursive: true })
 await writeFile(target, content, "utf8")
 await chmod(target, 0o755)


### PR DESCRIPTION
## Summary

- Fix `bunx note` / `npx note` which was broken because the published `bin.mjs` imported from `./Note.js` and `./Validate.js` (non-existent at package root) instead of `./dist/esm/Note.js` and `./dist/esm/Validate.js`