### PR TITLE
fix(security): require happy-dom >=20.0.0 to prevent VM escape RCE

### DIFF
--- a/packages-native/opentui-dom/package.json
+++ b/packages-native/opentui-dom/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "effect": "latest",
     "@effect/vitest": "latest",
-    "happy-dom": "^17.4.4",
+    "happy-dom": "^20.0.0",
     "@opentui/core": "^0.1.63",
     "react": "^19",
     "react-dom": "^19",


### PR DESCRIPTION
## Summary

- Bump minimum happy-dom version from `^17.4.4` to `^20.0.0` in opentui-dom

## Security Issue

happy-dom v19 and below contains a VM context escape vulnerability that allows untrusted JavaScript to access process-level functionality (RCE risk).

**Attack vector:** `this.constructor.constructor('return process')()` escapes the VM sandbox.

v20+ mitigates this by disabling JavaScript evaluation by default.

## References

- https://github.com/capricorn86/happy-dom/security/advisories/GHSA-v5vw-5q6x-26rp