### PR TITLE
chore: update pnpm-lock.yaml after happy-dom version bump

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2573,8 +2573,8 @@ packages:
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
-  '@types/web@0.0.310':
-    resolution: {integrity: sha512-XN++V7UZGEeRg8MXJBkzMqmcAWoCRN1UV/zpQxg9YnJQ9pIPSuzEG7oidC+nXi/J8pmfb3UgFv+TjEDzMiNnRg==}
+  '@types/web@0.0.309':
+    resolution: {integrity: sha512-8PEVqnrkAxokSEJPYjNqzmoOELlIrlHG4xsEb6oLOxMzsgqn/n6eYrgSYKG1QgptAcP88mmL7h2cpJQU60F3Qw==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -8752,7 +8752,7 @@ snapshots:
 
   '@types/unist@2.0.11': {}
 
-  '@types/web@0.0.310': {}
+  '@types/web@0.0.309': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -10102,7 +10102,7 @@ snapshots:
       '@types/babel__generator': 7.27.0
       '@types/dedent': 0.7.0
       '@types/eslint': 8.56.12
-      '@types/glob': '@types/web@0.0.310'
+      '@types/glob': '@types/web@0.0.309'
       '@types/js-yaml': 3.12.5
       '@types/lodash': 4.17.21
       cheerio: 1.1.2


### PR DESCRIPTION
## Summary

- Update lockfile to remove old happy-dom@17.6.3 resolution after PR #197

Follows up on the security fix in #197.