### PR TITLE
fix: enable JS evaluation in TestAdapter for happy-dom v20+

### DIFF
--- a/packages-native/opentui-dom/src/TestAdapter.ts
+++ b/packages-native/opentui-dom/src/TestAdapter.ts
@@ -34,7 +34,13 @@ let testDocument: Document | null = null
 async function ensureTestEnv(): Promise<{ window: HappyWindow; document: Document }> {
   if (!testDocument || !testWindow) {
     const { Window } = await import("happy-dom")
-    testWindow = new Window({ url: "https://localhost" })
+    testWindow = new Window({
+      url: "https://localhost",
+      settings: {
+        enableJavaScriptEvaluation: true,
+        suppressInsecureJavaScriptEnvironmentWarning: true
+      }
+    })
     testDocument = testWindow.document as unknown as Document
   }
   return { window: testWindow, document: testDocument }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2573,8 +2573,8 @@ packages:
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
-  '@types/web@0.0.310':
-    resolution: {integrity: sha512-XN++V7UZGEeRg8MXJBkzMqmcAWoCRN1UV/zpQxg9YnJQ9pIPSuzEG7oidC+nXi/J8pmfb3UgFv+TjEDzMiNnRg==}
+  '@types/web@0.0.309':
+    resolution: {integrity: sha512-8PEVqnrkAxokSEJPYjNqzmoOELlIrlHG4xsEb6oLOxMzsgqn/n6eYrgSYKG1QgptAcP88mmL7h2cpJQU60F3Qw==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -8752,7 +8752,7 @@ snapshots:
 
   '@types/unist@2.0.11': {}
 
-  '@types/web@0.0.310': {}
+  '@types/web@0.0.309': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -10102,7 +10102,7 @@ snapshots:
       '@types/babel__generator': 7.27.0
       '@types/dedent': 0.7.0
       '@types/eslint': 8.56.12
-      '@types/glob': '@types/web@0.0.310'
+      '@types/glob': '@types/web@0.0.309'
       '@types/js-yaml': 3.12.5
       '@types/lodash': 4.17.21
       cheerio: 1.1.2


### PR DESCRIPTION
## Summary

- Enable `enableJavaScriptEvaluation: true` in TestAdapter for happy-dom v20+
- Suppress the security warning since this is a controlled test environment

## Context

happy-dom v20 disables JavaScript evaluation by default for security (to prevent VM escape RCE). However, the test adapter needs JS evaluation enabled to support inline event handlers like `onclick="..."`.

This is safe in test environments where we control the code being executed.

Fixes test failure:
```
DOMAdapter > click() > triggers click on element
AssertionError: expected 'Click me' to be 'clicked'
```