### PR TITLE
fix(fetch-hooks): extract binary data URLs from request.json to sidec…

### DIFF
--- a/.changeset/binary-sidecar-extraction.md
+++ b/.changeset/binary-sidecar-extraction.md
@@ -1,0 +1,10 @@
+---
+"@effect-native/fetch-hooks": minor
+---
+
+Add binary data URL extraction to sidecar files for cache storage
+
+- Add `createRequestFileKV()` for request caching that extracts inline base64 data URLs (e.g., `data:image/png;base64,...`) to separate sidecar files like `request.json.assets/0001.png`
+- Add `createTextFileKV()` for response body caching with the same binary extraction behavior
+- Update `createFilesystemStorage()` to use these new KV implementations, improving cache readability and reducing JSON file bloat
+- Add comprehensive JSDoc documentation with examples for new functions

--- a/packages-native/fetch-hooks/src/filesystem-storage.ts
+++ b/packages-native/fetch-hooks/src/filesystem-storage.ts
@@ -45,7 +45,21 @@ export function createJsonFileKV<T>(baseDir: string, filename: string): KV<Cache
   }
 }
 
-/** Create a KV store for requests that extracts/restores inline base64 data URLs to sidecar files */
+/**
+ * Creates a KV store for HTTP requests that extracts inline base64 data URLs
+ * to sidecar files on disk and restores them when reading from the cache.
+ *
+ * @param baseDir - Base directory where cache entries are stored.
+ * @param filename - File name used to persist the cached request JSON.
+ * @returns A KV implementation keyed by CacheKey storing CachedRequest values.
+ * @since 1.0.0
+ * @example
+ * ```ts
+ * const kv = createRequestFileKV(".cache", "request.json")
+ * await kv.set(["some-cache-key"], cachedRequest)
+ * const value = await kv.get(["some-cache-key"])
+ * ```
+ */
 export function createRequestFileKV(baseDir: string, filename: string): KV<CacheKey, CachedRequest> {
   const assetsExt = ".assets"
 
@@ -55,9 +69,8 @@ export function createRequestFileKV(baseDir: string, filename: string): KV<Cache
       if (!existsSync(filePath)) {
         return null
       }
-      let content = readFileSync(filePath, "utf-8")
       const assetsDir = join(baseDir, key, filename + assetsExt)
-      content = restoreDataUrls(content, assetsDir)
+      const content = restoreDataUrls(readFileSync(filePath, "utf-8"), assetsDir)
       return JSON.parse(content) as CachedRequest
     },
 
@@ -65,9 +78,7 @@ export function createRequestFileKV(baseDir: string, filename: string): KV<Cache
       const cacheDir = ensureCacheDir(baseDir, key)
       const filePath = join(cacheDir, filename)
       const assetsDir = join(cacheDir, filename + assetsExt)
-      let content = JSON.stringify(value, null, 2)
-      const { content: extractedContent } = extractDataUrls(content, assetsDir)
-      content = extractedContent
+      const { content } = extractDataUrls(JSON.stringify(value, null, 2), assetsDir)
       writeFileSync(filePath, content, "utf-8")
     },
 
@@ -78,7 +89,21 @@ export function createRequestFileKV(baseDir: string, filename: string): KV<Cache
   }
 }
 
-/** Create a KV store for text files that extracts/restores inline base64 data URLs to sidecar files */
+/**
+ * Creates a KV store for text files that extracts inline base64 data URLs into
+ * sidecar asset files on disk and restores them when reading.
+ *
+ * @param baseDir - Base directory where cache entries are stored.
+ * @param filename - File name used for the cached text content within each cache key directory.
+ * @returns A KV store keyed by CacheKey that reads and writes text content from the filesystem.
+ * @since 1.0.0
+ * @example
+ * ```ts
+ * const kv = createTextFileKV("/tmp/fetch-hooks-cache", "response.txt")
+ * await kv.set(["my-cache-key"], "inline data: data:image/png;base64,...")
+ * const value = await kv.get(["my-cache-key"])
+ * ```
+ */
 export function createTextFileKV(baseDir: string, filename: string): KV<CacheKey, string> {
   const assetsExt = ".assets"
 
@@ -88,18 +113,16 @@ export function createTextFileKV(baseDir: string, filename: string): KV<CacheKey
       if (!existsSync(filePath)) {
         return null
       }
-      let content = readFileSync(filePath, "utf-8")
       const assetsDir = join(baseDir, key, filename + assetsExt)
-      content = restoreDataUrls(content, assetsDir)
-      return content
+      return restoreDataUrls(readFileSync(filePath, "utf-8"), assetsDir)
     },
 
     async set([key]: CacheKey, value: string): Promise<void> {
       const cacheDir = ensureCacheDir(baseDir, key)
       const filePath = join(cacheDir, filename)
       const assetsDir = join(cacheDir, filename + assetsExt)
-      const { content: extractedContent } = extractDataUrls(value, assetsDir)
-      writeFileSync(filePath, extractedContent, "utf-8")
+      const { content } = extractDataUrls(value, assetsDir)
+      writeFileSync(filePath, content, "utf-8")
     },
 
     async has([key]: CacheKey): Promise<boolean> {

--- a/packages-native/fetch-hooks/src/filesystem-storage.ts
+++ b/packages-native/fetch-hooks/src/filesystem-storage.ts
@@ -2,6 +2,7 @@ import type { CachedRequest, CachedResponseMeta, CacheKey, CacheStorage, KV, KVS
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
+import { extractDataUrls, restoreDataUrls } from "./binary-extractor.js"
 import { jsonlToTimedChunks, timedChunksToJsonl } from "./sse-handler.js"
 
 function ensureCacheDir(baseDir: string, cacheKey: string): string {
@@ -35,6 +36,70 @@ export function createJsonFileKV<T>(baseDir: string, filename: string): KV<Cache
       const cacheDir = ensureCacheDir(baseDir, key)
       const filePath = join(cacheDir, filename)
       writeFileSync(filePath, JSON.stringify(value, null, 2), "utf-8")
+    },
+
+    async has([key]: CacheKey): Promise<boolean> {
+      const filePath = join(baseDir, key, filename)
+      return existsSync(filePath)
+    }
+  }
+}
+
+/** Create a KV store for requests that extracts/restores inline base64 data URLs to sidecar files */
+export function createRequestFileKV(baseDir: string, filename: string): KV<CacheKey, CachedRequest> {
+  const assetsExt = ".assets"
+
+  return {
+    async get([key]: CacheKey): Promise<CachedRequest | null> {
+      const filePath = join(baseDir, key, filename)
+      if (!existsSync(filePath)) {
+        return null
+      }
+      let content = readFileSync(filePath, "utf-8")
+      const assetsDir = join(baseDir, key, filename + assetsExt)
+      content = restoreDataUrls(content, assetsDir)
+      return JSON.parse(content) as CachedRequest
+    },
+
+    async set([key]: CacheKey, value: CachedRequest): Promise<void> {
+      const cacheDir = ensureCacheDir(baseDir, key)
+      const filePath = join(cacheDir, filename)
+      const assetsDir = join(cacheDir, filename + assetsExt)
+      let content = JSON.stringify(value, null, 2)
+      const { content: extractedContent } = extractDataUrls(content, assetsDir)
+      content = extractedContent
+      writeFileSync(filePath, content, "utf-8")
+    },
+
+    async has([key]: CacheKey): Promise<boolean> {
+      const filePath = join(baseDir, key, filename)
+      return existsSync(filePath)
+    }
+  }
+}
+
+/** Create a KV store for text files that extracts/restores inline base64 data URLs to sidecar files */
+export function createTextFileKV(baseDir: string, filename: string): KV<CacheKey, string> {
+  const assetsExt = ".assets"
+
+  return {
+    async get([key]: CacheKey): Promise<string | null> {
+      const filePath = join(baseDir, key, filename)
+      if (!existsSync(filePath)) {
+        return null
+      }
+      let content = readFileSync(filePath, "utf-8")
+      const assetsDir = join(baseDir, key, filename + assetsExt)
+      content = restoreDataUrls(content, assetsDir)
+      return content
+    },
+
+    async set([key]: CacheKey, value: string): Promise<void> {
+      const cacheDir = ensureCacheDir(baseDir, key)
+      const filePath = join(cacheDir, filename)
+      const assetsDir = join(cacheDir, filename + assetsExt)
+      const { content: extractedContent } = extractDataUrls(value, assetsDir)
+      writeFileSync(filePath, extractedContent, "utf-8")
     },
 
     async has([key]: CacheKey): Promise<boolean> {
@@ -116,9 +181,9 @@ export function createJsonlFileKVStream(baseDir: string, filename: string): KVSt
 /** Create a complete CacheStorage backed by the filesystem */
 export function createFilesystemStorage(baseDir: string): CacheStorage {
   return {
-    requests: createJsonFileKV<CachedRequest>(baseDir, "request.json"),
+    requests: createRequestFileKV(baseDir, "request.json"),
     responseMeta: createJsonFileKV<CachedResponseMeta>(baseDir, "response.meta.json"),
-    responseBody: createJsonFileKV<string>(baseDir, "response.json"),
+    responseBody: createTextFileKV(baseDir, "response.json"),
     binaryBody: createBinaryFileKV(baseDir, "response.bin"),
     sseChunks: createJsonlFileKVStream(baseDir, "response.jsonl")
   }

--- a/packages-native/fetch-hooks/test/cache-manager.test.ts
+++ b/packages-native/fetch-hooks/test/cache-manager.test.ts
@@ -41,15 +41,20 @@ function findCachedResponse(cacheDir: string): { body: string; meta: unknown } |
     const responsePath = join(cacheDir, entry, "response.json")
     const metaPath = join(cacheDir, entry, "response.meta.json")
     if (existsSync(responsePath)) {
-      const bodyContent = JSON.parse(readFileSync(responsePath, "utf-8"))
-      // New format: response.json contains just the body string, meta is separate
-      if (typeof bodyContent === "string" && existsSync(metaPath)) {
+      const rawContent = readFileSync(responsePath, "utf-8")
+      // New format: response.json contains raw text body, meta is separate
+      if (existsSync(metaPath)) {
         const meta = JSON.parse(readFileSync(metaPath, "utf-8"))
-        return { body: bodyContent, meta }
+        return { body: rawContent, meta }
       }
-      // Old format: response.json contains {body, meta}
-      if (bodyContent && typeof bodyContent.body === "string") {
-        return bodyContent
+      // Old format: response.json contains {body, meta} as JSON
+      try {
+        const bodyContent = JSON.parse(rawContent)
+        if (bodyContent && typeof bodyContent.body === "string") {
+          return bodyContent
+        }
+      } catch {
+        // Not valid JSON, skip
       }
     }
   }
@@ -748,3 +753,115 @@ async function collectSSEEvents(response: Response): Promise<Array<{ type: strin
 
   return events
 }
+
+describe("Binary extraction in request.json", () => {
+  const testCacheDir = join(process.cwd(), ".cache", "fetch-test-binary-request")
+
+  beforeEach(() => {
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true })
+    }
+    mkdirSync(testCacheDir, { recursive: true })
+    process.env.DEV_FETCH_CACHE_DIR = testCacheDir
+  })
+
+  afterEach(() => {
+    delete process.env.DEV_FETCH_CACHE_DIR
+    if (existsSync(testCacheDir)) {
+      rmSync(testCacheDir, { recursive: true })
+    }
+  })
+
+  it("extracts inline base64 data URLs from request body to sidecar files", async () => {
+    const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    const mockFetch = async () => new Response("ok", { status: 200 })
+    const cachedFetch = createCachedFetch(mockFetch as unknown as typeof fetch)
+
+    await cachedFetch("https://api.example.com/upload", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        image: `data:image/png;base64,${pngBase64}`
+      })
+    })
+
+    // Find the cache entry
+    const entries = readdirSync(testCacheDir)
+    expect(entries.length).toBeGreaterThan(0)
+    const cacheEntry = entries[0]
+    const requestPath = join(testCacheDir, cacheEntry, "request.json")
+    const assetsDir = join(testCacheDir, cacheEntry, "request.json.assets")
+
+    // Verify request.json contains sidecar reference, not raw base64
+    const rawRequestJson = readFileSync(requestPath, "utf-8")
+    expect(rawRequestJson).toContain("__sidecar:0001.png__")
+    expect(rawRequestJson).not.toContain(pngBase64)
+
+    // Verify sidecar file was created
+    expect(existsSync(assetsDir)).toBe(true)
+    const sidecarFile = join(assetsDir, "0001.png")
+    expect(existsSync(sidecarFile)).toBe(true)
+
+    // Verify sidecar file contains the decoded binary
+    const sidecarContent = readFileSync(sidecarFile)
+    const expectedContent = Buffer.from(pngBase64, "base64")
+    expect(sidecarContent).toEqual(expectedContent)
+  })
+
+  it("extracts inline base64 data URLs from response body to sidecar files", async () => {
+    const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    const mock = createMockFetch((_url) =>
+      new Response(
+        JSON.stringify({ image: `data:image/png;base64,${pngBase64}` }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    )
+    const cachedFetch = createCachedFetch(mock.fetch)
+
+    const response = await cachedFetch("https://api.example.com/image")
+    await response.text() // consume to trigger storage
+
+    // Find the cache entry
+    const entries = readdirSync(testCacheDir)
+    expect(entries.length).toBeGreaterThan(0)
+    const cacheEntry = entries[0]
+    const responsePath = join(testCacheDir, cacheEntry, "response.json")
+    const assetsDir = join(testCacheDir, cacheEntry, "response.json.assets")
+
+    // Verify response.json contains sidecar reference, not raw base64
+    const rawResponseJson = readFileSync(responsePath, "utf-8")
+    expect(rawResponseJson).toContain("__sidecar:0001.png__")
+    expect(rawResponseJson).not.toContain(pngBase64)
+
+    // Verify sidecar file was created
+    expect(existsSync(assetsDir)).toBe(true)
+    const sidecarFile = join(assetsDir, "0001.png")
+    expect(existsSync(sidecarFile)).toBe(true)
+  })
+
+  it("restores data URLs when reading cached request", async () => {
+    const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    const originalBody = { image: `data:image/png;base64,${pngBase64}` }
+    const mockFetch = async () => new Response("ok", { status: 200 })
+    const cachedFetch = createCachedFetch(mockFetch as unknown as typeof fetch)
+
+    // Store request with base64 data URL
+    await cachedFetch("https://api.example.com/upload", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(originalBody)
+    })
+
+    // Use the storage abstraction to read back - it should restore the data URL
+    const { createFilesystemStorage } = await import("../src/filesystem-storage")
+    const storage = createFilesystemStorage(testCacheDir)
+
+    const entries = readdirSync(testCacheDir)
+    const cacheKey = entries[0]
+    const cached = await storage.requests.get([cacheKey])
+
+    expect(cached).not.toBeNull()
+    // The restored body.json should have the original data URL
+    expect(cached!.body).toEqual({ json: originalBody })
+  })
+})

--- a/packages-native/fetch-hooks/test/cache-manager.test.ts
+++ b/packages-native/fetch-hooks/test/cache-manager.test.ts
@@ -864,4 +864,29 @@ describe("Binary extraction in request.json", () => {
     // The restored body.json should have the original data URL
     expect(cached!.body).toEqual({ json: originalBody })
   })
+
+  it("restores data URLs when reading cached response body", async () => {
+    const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    const originalBody = JSON.stringify({ image: `data:image/png;base64,${pngBase64}` })
+    const mock = createMockFetch((_url) =>
+      new Response(originalBody, { status: 200, headers: { "content-type": "application/json" } })
+    )
+    const cachedFetch = createCachedFetch(mock.fetch)
+
+    // Store response with base64 data URL
+    const response = await cachedFetch("https://api.example.com/image-restore")
+    await response.text() // consume to trigger storage
+
+    // Use the storage abstraction to read back - it should restore the data URL
+    const { createFilesystemStorage } = await import("../src/filesystem-storage")
+    const storage = createFilesystemStorage(testCacheDir)
+
+    const entries = readdirSync(testCacheDir)
+    const cacheKey = entries[0]
+    const cachedBody = await storage.responseBody.get([cacheKey])
+
+    expect(cachedBody).not.toBeNull()
+    // The restored response body should have the original data URL
+    expect(cachedBody).toEqual(originalBody)
+  })
 })


### PR DESCRIPTION
…ar files

- Add createRequestFileKV() for requests that extracts/restores inline base64 data URLs (data:image/png;base64,...) to sidecar files like request.json.assets/0001.png

- Add createTextFileKV() for response bodies with same binary extraction

- Update createFilesystemStorage() to use new KV types for requests and response bodies

- Update test helper findCachedResponse() to handle raw text format

- Add tests verifying binary extraction/restoration for both requests and responses