### PR TITLE
chore: release @effect-native/bun-test beta from v4

### DIFF
--- a/.changeset/bun-test-beta-release.md
+++ b/.changeset/bun-test-beta-release.md
@@ -1,0 +1,5 @@
+---
+"@effect-native/bun-test": patch
+---
+
+Publish a beta prerelease of `@effect-native/bun-test` via Changesets on `v4`.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,9 +7,9 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "effect-native/main",
+  "baseBranch": "v4",
   "updateInternalDependencies": "patch",
-  "ignore": ["scratchpad"],
+  "ignore": ["scratchpad", "@effect-native/name-checker"],
   "snapshot": {
     "useCalculatedVersion": false,
     "prereleaseTemplate": "{tag}-{commit}"

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,25 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@effect-native/bun-test": "0.1.3",
+    "@effect-native/crsql": "0.3.0",
+    "@effect-native/debug": "0.1.0",
+    "effect-native": "0.1.0",
+    "@effect-native/examples-tui-testing-library": "0.0.0",
+    "@effect-native/fetch-hooks": "0.1.0",
+    "@effect-native/libcrsql": "0.16.303",
+    "@effect-native/libsqlite": "3.50.203",
+    "@effect-native/name-checker": "0.1.0",
+    "note": "0.3.1",
+    "@effect-native/openrouter": "0.1.0",
+    "@effect-native/opentui-dom": "0.1.0",
+    "@effect-native/opentui-dom-testing-library": "0.1.0",
+    "@effect-native/patterns": "0.1.0",
+    "@effect-native/schemas": "0.1.0",
+    "ssh-keep": "0.0.1-placeholder",
+    "@effect-native/tui-testing-library": "0.1.0",
+    "scratchpad": "0.0.0"
+  },
+  "changesets": []
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   push:
-    branches: [effect-native/main]
+    branches: [effect-native/main, v4]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- prepare Changesets prerelease mode with beta tag for v4
- add a changeset to publish @effect-native/bun-test as 0.1.4-beta.0
- exclude @effect-native/name-checker from Changesets publishing (not needed)
- allow Release workflow to run on v4 pushes

## Verification
- pnpm dlx @changesets/cli@2.29.8 status --verbose => only @effect-native/bun-test 0.1.4-beta.0
