### PR TITLE
chore: make @effect-native/name-checker private

### DIFF
--- a/packages-native/name-checker/package.json
+++ b/packages-native/name-checker/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@effect-native/name-checker",
   "version": "0.1.0",
+  "private": true,
   "type": "module",
   "license": "MIT",
   "description": "Check domain and npm package name availability with AI suggestions",


### PR DESCRIPTION
Exclude name-checker from npm publishing on v4 so release workflows do not fail on its publish attempt.