### PR TITLE
chore: update root resolutions to effect@beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "resolutions": {
     "autolinker": "^3.16.2",
-    "effect": "latest",
+    "effect": "beta",
     "dependency-tree": "^10.0.9",
     "detective-amd": "^5.0.2",
     "detective-cjs": "^5.0.1",
@@ -49,7 +49,7 @@
     "@effect/docgen": "^0.5.2",
     "@effect/eslint-plugin": "^0.3.2",
     "@effect/language-service": "^0.23.5",
-    "@effect/vitest": "latest",
+    "@effect/vitest": "beta",
     "@eslint/compat": "^1.3.2",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.39.2",


### PR DESCRIPTION
## Summary

Updates the root workspace to resolve `effect` to the `beta` dist-tag, enabling all packages to use Effect v4.

- `resolutions.effect`: `latest` → `beta`
- `devDependencies.@effect/vitest`: `latest` → `beta`

All per-package beta migration PRs are stacked on top of this branch.