### PR TITLE
chore(ssh-keep): update effect dep to beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "resolutions": {
     "autolinker": "^3.16.2",
-    "effect": "latest",
+    "effect": "beta",
     "dependency-tree": "^10.0.9",
     "detective-amd": "^5.0.2",
     "detective-cjs": "^5.0.1",
@@ -49,7 +49,7 @@
     "@effect/docgen": "^0.5.2",
     "@effect/eslint-plugin": "^0.3.2",
     "@effect/language-service": "^0.23.5",
-    "@effect/vitest": "latest",
+    "@effect/vitest": "beta",
     "@eslint/compat": "^1.3.2",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.39.2",

--- a/packages-native/ssh-keep/package.json
+++ b/packages-native/ssh-keep/package.json
@@ -13,5 +13,8 @@
   },
   "scripts": {
     "check": "echo 'nothing to check'"
+  },
+  "dependencies": {
+    "effect": "beta"
   }
 }


### PR DESCRIPTION
## Summary

Updates `ssh-keep` for Effect v4 compatibility.

- `dependencies.effect`: `latest` → `beta`

Stacked on #221 (root resolutions update).