### PR TITLE
chore(examples-tui-testing-library): update effect dev dep to beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "resolutions": {
     "autolinker": "^3.16.2",
-    "effect": "latest",
+    "effect": "beta",
     "dependency-tree": "^10.0.9",
     "detective-amd": "^5.0.2",
     "detective-cjs": "^5.0.1",
@@ -49,7 +49,7 @@
     "@effect/docgen": "^0.5.2",
     "@effect/eslint-plugin": "^0.3.2",
     "@effect/language-service": "^0.23.5",
-    "@effect/vitest": "latest",
+    "@effect/vitest": "beta",
     "@eslint/compat": "^1.3.2",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.39.2",

--- a/packages-native/examples-tui-testing-library/package.json
+++ b/packages-native/examples-tui-testing-library/package.json
@@ -15,6 +15,6 @@
     "@effect-native/bun-test": "workspace:*",
     "@types/bun": "latest",
     "@types/node": "latest",
-    "effect": "latest"
+    "effect": "beta"
   }
 }


### PR DESCRIPTION
## Summary

Updates `@effect-native/examples-tui-testing-library` for Effect v4 compatibility.

- `devDependencies.effect`: `latest` → `beta`

Stacked on #221 (root resolutions update).