### PR TITLE
chore(patterns): update effect deps to beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "resolutions": {
     "autolinker": "^3.16.2",
-    "effect": "latest",
+    "effect": "beta",
     "dependency-tree": "^10.0.9",
     "detective-amd": "^5.0.2",
     "detective-cjs": "^5.0.1",
@@ -49,7 +49,7 @@
     "@effect/docgen": "^0.5.2",
     "@effect/eslint-plugin": "^0.3.2",
     "@effect/language-service": "^0.23.5",
-    "@effect/vitest": "latest",
+    "@effect/vitest": "beta",
     "@eslint/compat": "^1.3.2",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.39.2",

--- a/packages-native/patterns/package.json
+++ b/packages-native/patterns/package.json
@@ -38,10 +38,10 @@
     "coverage": "vitest --coverage"
   },
   "peerDependencies": {
-    "effect": "^3.19.0"
+    "effect": "^4.0.0-beta.0"
   },
   "devDependencies": {
-    "effect": "latest",
-    "@effect/vitest": "latest"
+    "effect": "beta",
+    "@effect/vitest": "beta"
   }
 }

--- a/packages-native/patterns/src/CodexSession.ts
+++ b/packages-native/patterns/src/CodexSession.ts
@@ -35,7 +35,7 @@ const SandboxPolicy = Schema.Struct({
 })
 
 const MessageFragmentPayload = Schema.Struct({
-  type: Schema.Literal("input_text", "output_text"),
+  type: Schema.Literals(["input_text", "output_text"]),
   text: Schema.String
 })
 
@@ -199,12 +199,12 @@ const TurnContextSchema = Schema.Struct({
 const MessageFragmentSchema = MessageFragmentPayload
 const SummaryFragmentSchema = SummaryFragmentPayload
 
-const ResponsePayloadSchema = Schema.Union(
+const ResponsePayloadSchema = Schema.Union([
   ResponseMessagePayload,
   ResponseFunctionCallPayload,
   ResponseFunctionCallOutputPayload,
   ResponseReasoningPayload
-)
+])
 
 const ResponseItemSchema = Schema.Struct({
   timestamp: Timestamp,
@@ -212,7 +212,7 @@ const ResponseItemSchema = Schema.Struct({
   payload: ResponsePayloadSchema
 })
 
-const EventPayloadSchema = Schema.Union(
+const EventPayloadSchema = Schema.Union([
   TokenCountPayload,
   TurnAbortedPayload,
   AgentReasoningPayload,
@@ -220,7 +220,7 @@ const EventPayloadSchema = Schema.Union(
   UserMessagePayload,
   EnteredReviewPayload,
   ExitedReviewPayload
-)
+])
 
 const EventMessageSchema = Schema.Struct({
   timestamp: Timestamp,
@@ -234,7 +234,7 @@ const CompactedSchema = Schema.Struct({
   payload: CompactedPayload
 })
 
-const SessionEntrySchema = Schema.Union(
+const SessionEntrySchema = Schema.Union([
   SessionHeaderSchema,
   SessionMetaSchema,
   TurnContextSchema,
@@ -245,7 +245,7 @@ const SessionEntrySchema = Schema.Union(
   LegacyReasoningPayload,
   LegacyFunctionCallPayload,
   LegacyFunctionCallOutputPayload
-)
+])
 
 const SessionSchema = Schema.Array(SessionEntrySchema)
 

--- a/packages-native/patterns/src/internal/list.ts
+++ b/packages-native/patterns/src/internal/list.ts
@@ -56,7 +56,7 @@ const hashList = (self: List<unknown>): number => {
     hash = Hash.combine(Hash.hash(current.head))(hash)
     current = current.tail
   }
-  return Hash.cached(self, hash)
+  return hash
 }
 
 const Proto = {

--- a/packages-native/patterns/src/internal/thing.ts
+++ b/packages-native/patterns/src/internal/thing.ts
@@ -52,7 +52,7 @@ const hashThing = (self: Thing<unknown>): number => {
   hash = Hash.combine(Hash.hash(self.label))(hash)
   hash = Hash.combine(Hash.hash(self.value))(hash)
   hash = Hash.combine(Hash.array(self.tags))(hash)
-  return Hash.cached(self, hash)
+  return hash
 }
 
 const Proto = {

--- a/packages-native/patterns/src/internal/tree.ts
+++ b/packages-native/patterns/src/internal/tree.ts
@@ -50,7 +50,7 @@ const hashTree = (self: Tree<unknown>): number => {
   for (const child of self.children) {
     hash = Hash.combine(Hash.hash(child))(hash)
   }
-  return Hash.cached(self, hash)
+  return hash
 }
 
 const Proto = {

--- a/packages-native/patterns/test/CodexSession.test.ts
+++ b/packages-native/patterns/test/CodexSession.test.ts
@@ -155,14 +155,14 @@ const sampleSession = [
 describe("CodexSession", () => {
   it.effect("decodes Codex CLI session JSONL entries", () =>
     Effect.gen(function*() {
-      const decoded = yield* Schema.decodeUnknown(CodexSession.Session)(sampleSession)
+      const decoded = yield* Schema.decodeUnknownEffect(CodexSession.Session)(sampleSession)
       assert.strictEqual(decoded.length, sampleSession.length)
 
       const first = decoded[0]
       assert.ok(first && "type" in first)
       assert.strictEqual(first.type, "session_meta")
 
-      const encoded = yield* Schema.encode(CodexSession.Session)(decoded)
+      const encoded = yield* Schema.encodeEffect(CodexSession.Session)(decoded)
       assert.deepStrictEqual(encoded, sampleSession)
     }))
 })

--- a/packages-native/patterns/test/Thing.test.ts
+++ b/packages-native/patterns/test/Thing.test.ts
@@ -5,6 +5,8 @@ import * as Equal from "effect/Equal"
 import * as Hash from "effect/Hash"
 import * as HashSet from "effect/HashSet"
 
+class Counter extends Data.Class<{ readonly count: number }> {}
+
 describe("Thing", () => {
   it("make creates TypeId-tagged instances and isThing recognizes them", () => {
     const original = Thing.make({ id: "alpha", label: "demo", value: 1 })
@@ -17,8 +19,8 @@ describe("Thing", () => {
   })
 
   it("instances obey Equal and Hash protocols", () => {
-    const left = Thing.make({ id: "alpha", label: "demo", value: Data.struct({ count: 1 }) })
-    const right = Thing.make({ id: "alpha", label: "demo", value: Data.struct({ count: 1 }) })
+    const left = Thing.make({ id: "alpha", label: "demo", value: new Counter({ count: 1 }) })
+    const right = Thing.make({ id: "alpha", label: "demo", value: new Counter({ count: 1 }) })
 
     assert.isTrue(Equal.equals(left, right))
     assert.strictEqual(Hash.hash(left), Hash.hash(right))

--- a/packages-native/patterns/test/Tree.test.ts
+++ b/packages-native/patterns/test/Tree.test.ts
@@ -5,6 +5,8 @@ import * as Effect from "effect/Effect"
 import * as Equal from "effect/Equal"
 import * as Hash from "effect/Hash"
 
+class NodeData extends Data.Class<{ readonly id: number }> {}
+
 describe("Tree", () => {
   const makeExample = () =>
     Tree.make({
@@ -19,7 +21,7 @@ describe("Tree", () => {
     })
 
   it("make produces Tree instances tagged with TypeId", () => {
-    const tree = Tree.make({ value: Data.struct({ id: 1 }) })
+    const tree = Tree.make({ value: new NodeData({ id: 1 }) })
 
     assert.isTrue(Tree.isTree(tree))
     assert.strictEqual(tree.value.id, 1)


### PR DESCRIPTION
## Summary

Updates `@effect-native/patterns` for Effect v4 compatibility.

- `peerDependencies.effect`: `^3.19.0` → `^4.0.0-beta.0`
- `devDependencies.effect`: `latest` → `beta`
- `devDependencies.@effect/vitest`: `latest` → `beta`

Stacked on #221 (root resolutions update).