### PR TITLE
chore(schemas): update effect deps to beta

### DIFF
--- a/packages-native/schemas/package.json
+++ b/packages-native/schemas/package.json
@@ -36,10 +36,10 @@
     "coverage": "vitest --coverage"
   },
   "peerDependencies": {
-    "effect": "^3.19.0"
+    "effect": "^4.0.0-beta.0"
   },
   "devDependencies": {
-    "effect": "latest",
-    "@effect/vitest": "latest"
+    "effect": "beta",
+    "@effect/vitest": "beta"
   }
 }

--- a/packages-native/schemas/src/Slug.ts
+++ b/packages-native/schemas/src/Slug.ts
@@ -46,7 +46,7 @@ export const slugify = (title: string): string =>
  * @since 0.1.0
  * @category Schema
  */
-export const Slug: Schema.Schema<string, string> = Schema.String.pipe(
+export const Slug = Schema.String.pipe(
   Schema.decodeTo(Schema.String, {
     decode: SchemaGetter.transform(slugify),
     encode: SchemaGetter.transform((slug) => slug)
@@ -81,7 +81,7 @@ export type SlugBrand = typeof SlugBrandedString.Type
  * @since 0.1.0
  * @category Schema
  */
-export const SlugBranded: Schema.Schema<SlugBrand, string> = Schema.String.pipe(
+export const SlugBranded = Schema.String.pipe(
   Schema.decodeTo(SlugBrandedString, {
     decode: SchemaGetter.transform(slugify),
     encode: SchemaGetter.transform((slug) => slug)

--- a/packages-native/schemas/src/Slug.ts
+++ b/packages-native/schemas/src/Slug.ts
@@ -5,6 +5,7 @@
  */
 
 import * as Schema from "effect/Schema"
+import * as SchemaGetter from "effect/SchemaGetter"
 
 /**
  * Converts a title string to a URL-safe slug.
@@ -45,14 +46,11 @@ export const slugify = (title: string): string =>
  * @since 0.1.0
  * @category Schema
  */
-export const Slug: Schema.Schema<string, string> = Schema.transform(
-  Schema.String,
-  Schema.String,
-  {
-    strict: true,
-    decode: slugify,
-    encode: (slug) => slug
-  }
+export const Slug: Schema.Schema<string, string> = Schema.String.pipe(
+  Schema.decodeTo(Schema.String, {
+    decode: SchemaGetter.transform(slugify),
+    encode: SchemaGetter.transform((slug) => slug)
+  })
 )
 
 /**
@@ -83,12 +81,9 @@ export type SlugBrand = typeof SlugBrandedString.Type
  * @since 0.1.0
  * @category Schema
  */
-export const SlugBranded: Schema.Schema<SlugBrand, string> = Schema.transform(
-  Schema.String,
-  SlugBrandedString,
-  {
-    strict: true,
-    decode: slugify,
-    encode: (slug) => slug
-  }
+export const SlugBranded: Schema.Schema<SlugBrand, string> = Schema.String.pipe(
+  Schema.decodeTo(SlugBrandedString, {
+    decode: SchemaGetter.transform(slugify),
+    encode: SchemaGetter.transform((slug) => slug)
+  })
 )

--- a/packages-native/ssh-keep/src/cli.ts
+++ b/packages-native/ssh-keep/src/cli.ts
@@ -113,7 +113,7 @@ fi
 const proc = Bun.spawn(["ssh", "-t", host, remoteCommand], {
   stdin: "inherit",
   stdout: "inherit",
-  stderr: "inherit",
+  stderr: "inherit"
 })
 
 const exitCode = await proc.exited

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,8 +401,8 @@ importers:
         version: 4.0.0-beta.6
     devDependencies:
       '@effect/vitest':
-        specifier: latest
-        version: 0.27.0(effect@4.0.0-beta.6)(vitest@3.2.4)
+        specifier: beta
+        version: 4.0.0-beta.6(effect@4.0.0-beta.6)(vitest@3.2.4)
     publishDirectory: dist
 
   packages-native/ssh-keep: {}
@@ -7634,7 +7634,7 @@ snapshots:
   '@effect/vitest@4.0.0-beta.6(effect@4.0.0-beta.6)(vitest@3.2.4)':
     dependencies:
       effect: 4.0.0-beta.6
-      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.3)(@vitest/browser@3.2.4)(happy-dom@20.0.11)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.0.3)(@vitest/browser@3.2.4)(happy-dom@20.0.11)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@effect/wa-sqlite@0.1.2': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         version: 0.23.5
       '@effect/vitest':
         specifier: beta
-        version: 4.0.0-beta.6(effect@4.0.0-beta.6)(vitest@3.2.4)
+        version: 4.0.0-beta.6(effect@4.0.0-beta.8)(vitest@3.2.4)
       '@eslint/compat':
         specifier: ^1.3.2
         version: 1.4.1(eslint@9.39.2)
@@ -305,6 +305,22 @@ importers:
         version: 4.0.0-beta.6
     publishDirectory: dist
 
+  packages-native/name-checker:
+    dependencies:
+      '@effect-native/fetch-hooks':
+        specifier: workspace:*
+        version: link:../fetch-hooks
+      '@effect-native/openrouter':
+        specifier: workspace:*
+        version: link:../openrouter
+    devDependencies:
+      effect:
+        specifier: beta
+        version: 4.0.0-beta.8
+      tsx:
+        specifier: latest
+        version: 4.21.0
+
   packages-native/note:
     dependencies:
       '@effect-native/schemas':
@@ -326,6 +342,20 @@ importers:
       '@effect/vitest':
         specifier: latest
         version: 0.27.0(effect@4.0.0-beta.6)(vitest@3.2.4)
+    publishDirectory: dist
+
+  packages-native/openrouter:
+    dependencies:
+      '@openrouter/sdk':
+        specifier: ^0.3.10
+        version: 0.3.16
+      effect:
+        specifier: beta
+        version: 4.0.0-beta.8
+    devDependencies:
+      '@effect/vitest':
+        specifier: beta
+        version: 4.0.0-beta.8(effect@4.0.0-beta.8)(vitest@3.2.4)
     publishDirectory: dist
 
   packages-native/opentui-dom:
@@ -390,8 +420,8 @@ importers:
         version: 4.0.0-beta.6
     devDependencies:
       '@effect/vitest':
-        specifier: latest
-        version: 0.27.0(effect@4.0.0-beta.6)(vitest@3.2.4)
+        specifier: beta
+        version: 4.0.0-beta.8(effect@4.0.0-beta.6)(vitest@3.2.4)
     publishDirectory: dist
 
   packages-native/schemas:
@@ -405,7 +435,11 @@ importers:
         version: 4.0.0-beta.6(effect@4.0.0-beta.6)(vitest@3.2.4)
     publishDirectory: dist
 
-  packages-native/ssh-keep: {}
+  packages-native/ssh-keep:
+    dependencies:
+      effect:
+        specifier: beta
+        version: 4.0.0-beta.8
 
   packages-native/tui-testing-library:
     dependencies:
@@ -423,8 +457,8 @@ importers:
         specifier: workspace:*
         version: link:../bun-test
       '@effect/vitest':
-        specifier: latest
-        version: 0.27.0(effect@4.0.0-beta.6)(vitest@3.2.4)
+        specifier: beta
+        version: 4.0.0-beta.8(effect@4.0.0-beta.6)(vitest@3.2.4)
       '@types/bun':
         specifier: latest
         version: 1.3.5
@@ -1333,6 +1367,12 @@ packages:
       effect: ^4.0.0-beta.6
       vitest: ^3.0.0
 
+  '@effect/vitest@4.0.0-beta.8':
+    resolution: {integrity: sha512-CnwGyFhEOaGWhEfTLtUSC8Yq1losYk+V6Aepc18um8NkOHnbr5fLClE+XqNFPO1DN6Ehs6Kv/ms3Di2kw9/9Kg==}
+    peerDependencies:
+      effect: ^4.0.0-beta.8
+      vitest: ^3.0.0
+
   '@effect/wa-sqlite@0.1.2':
     resolution: {integrity: sha512-2JvJ9BDkBOwfeY/gXsC0XwEKC0AwisP2W5ABJ6mx14QyXTK12MGDIybDlHieuZt1TEFSMiKfpg7yyqyRWRooJQ==}
 
@@ -2040,6 +2080,9 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '>0.73.0'
+
+  '@openrouter/sdk@0.3.16':
+    resolution: {integrity: sha512-WEBlrXdc5R8I7o2temkMV65tIRGkzg9ct4DMNZ/FHS/hiRscLRS5EpcuORnAgjzZAh9X2dSsBpgygM8T7KiNAw==}
 
   '@opentelemetry/semantic-conventions@1.38.0':
     resolution: {integrity: sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==}
@@ -3627,6 +3670,9 @@ packages:
 
   effect@4.0.0-beta.6:
     resolution: {integrity: sha512-2xpzTi1f8eRYByMYso/vBiZGCvK74dVOMHOnXbwgzZQg6t5JaZ6ov7i5AU/vKPtb2y9FJbZwhf8owXBZq+LY0g==}
+
+  effect@4.0.0-beta.8:
+    resolution: {integrity: sha512-8Df3vdVY8ahZcn2oC27lAfMGXHId1I5YDHqGgLe4UCQ9D8Kzmb5oq+qZVXvmY9fZANabnu47AE41040kc52QCg==}
 
   electron-to-chromium@1.5.262:
     resolution: {integrity: sha512-NlAsMteRHek05jRUxUR0a5jpjYq9ykk6+kO0yRaMi5moe7u0fVIOeQ3Y30A8dIiWFBNUoQGi1ljb1i5VtS9WQQ==}
@@ -7636,6 +7682,21 @@ snapshots:
       effect: 4.0.0-beta.6
       vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.0.3)(@vitest/browser@3.2.4)(happy-dom@20.0.11)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  '@effect/vitest@4.0.0-beta.6(effect@4.0.0-beta.8)(vitest@3.2.4)':
+    dependencies:
+      effect: 4.0.0-beta.8
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.3)(@vitest/browser@3.2.4)(happy-dom@20.0.11)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@effect/vitest@4.0.0-beta.8(effect@4.0.0-beta.6)(vitest@3.2.4)':
+    dependencies:
+      effect: 4.0.0-beta.6
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.0.3)(@vitest/browser@3.2.4)(happy-dom@20.0.11)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@effect/vitest@4.0.0-beta.8(effect@4.0.0-beta.8)(vitest@3.2.4)':
+    dependencies:
+      effect: 4.0.0-beta.8
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.0.3)(@vitest/browser@3.2.4)(happy-dom@20.0.11)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
   '@effect/wa-sqlite@0.1.2': {}
 
   '@effect/workflow@0.16.0(@effect/experimental@0.58.0(@effect/platform@0.94.1(effect@4.0.0-beta.6))(effect@4.0.0-beta.6))(@effect/platform@0.94.1(effect@4.0.0-beta.6))(@effect/rpc@0.73.0(@effect/platform@0.94.1(effect@4.0.0-beta.6))(effect@4.0.0-beta.6))(effect@4.0.0-beta.6)':
@@ -8309,6 +8370,10 @@ snapshots:
     dependencies:
       react: 19.2.0
       react-native: 0.82.1(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.0)
+
+  '@openrouter/sdk@0.3.16':
+    dependencies:
+      zod: 3.25.76
 
   '@opentelemetry/semantic-conventions@1.38.0': {}
 
@@ -9896,6 +9961,19 @@ snapshots:
   ee-first@1.1.1: {}
 
   effect@4.0.0-beta.6:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 4.5.3
+      find-my-way-ts: 0.1.6
+      ini: 6.0.0
+      kubernetes-types: 1.30.0
+      msgpackr: 1.11.8
+      multipasta: 0.2.7
+      toml: 3.0.0
+      uuid: 13.0.0
+      yaml: 2.8.2
+
+  effect@4.0.0-beta.8:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.5.3


### PR DESCRIPTION
## Summary

Updates `@effect-native/schemas` for Effect v4 compatibility.

- `peerDependencies.effect`: `^3.19.0` → `^4.0.0-beta.0`
- `devDependencies.effect`: `latest` → `beta`
- `devDependencies.@effect/vitest`: `latest` → `beta`

Stacked on #221 (root resolutions update).