### PR TITLE
chore(openrouter): update effect deps to beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "resolutions": {
     "autolinker": "^3.16.2",
-    "effect": "latest",
+    "effect": "beta",
     "dependency-tree": "^10.0.9",
     "detective-amd": "^5.0.2",
     "detective-cjs": "^5.0.1",
@@ -49,7 +49,7 @@
     "@effect/docgen": "^0.5.2",
     "@effect/eslint-plugin": "^0.3.2",
     "@effect/language-service": "^0.23.5",
-    "@effect/vitest": "latest",
+    "@effect/vitest": "beta",
     "@eslint/compat": "^1.3.2",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.39.2",

--- a/packages-native/openrouter/LICENSE
+++ b/packages-native/openrouter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Effect-Native
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages-native/openrouter/README.md
+++ b/packages-native/openrouter/README.md
@@ -1,0 +1,3 @@
+# @effect-native/openrouter
+
+Effect-based OpenRouter client.

--- a/packages-native/openrouter/package.json
+++ b/packages-native/openrouter/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@effect-native/openrouter",
+  "version": "0.1.0",
+  "type": "module",
+  "license": "MIT",
+  "description": "Effect-based OpenRouter client.",
+  "homepage": "https://github.com/effect-native/effect-native",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/effect-native/effect-native.git",
+    "directory": "packages-native/openrouter"
+  },
+  "bugs": {
+    "url": "https://github.com/effect-native/effect-native/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "directory": "dist",
+    "linkDirectory": false
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./internal/*": null
+  },
+  "scripts": {
+    "codegen": "echo '@effect-native/openrouter: nothing to codegen'",
+    "build": "pnpm build-esm && pnpm build-annotate && pnpm build-cjs && build-utils pack-v3",
+    "build-esm": "tsc -b tsconfig.build.json",
+    "build-cjs": "babel build/esm --plugins @babel/transform-export-namespace-from --plugins @babel/transform-modules-commonjs --out-dir build/cjs --source-maps",
+    "build-annotate": "babel build/esm --plugins annotate-pure-calls --out-dir build/esm --source-maps",
+    "check": "tsc -b tsconfig.json",
+    "test": "vitest",
+    "coverage": "vitest --coverage"
+  },
+  "peerDependencies": {
+    "effect": "^4.0.0-beta.0"
+  },
+  "dependencies": {
+    "@openrouter/sdk": "^0.3.10"
+  },
+  "devDependencies": {
+    "effect": "beta",
+    "@effect/vitest": "beta"
+  }
+}

--- a/packages-native/openrouter/src/index.ts
+++ b/packages-native/openrouter/src/index.ts
@@ -1,5 +1,5 @@
 import * as OR from "@openrouter/sdk"
-import { Config, Effect, Layer, Schema, Stream } from "effect"
+import { Config, Data, Effect, Layer, ServiceMap, Stream } from "effect"
 
 /** Simple chat completion request (workaround for SDK response validation bug) */
 export interface ChatRequest {
@@ -19,190 +19,220 @@ export interface ChatResponse {
   usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number }
 }
 
-export class OpenRouterError extends Schema.TaggedError<OpenRouterError>()("OpenRouterError", {
-  message: Schema.String,
-  cause: Schema.Defect.pipe(Schema.optional)
-}) {}
+export class OpenRouterError extends Data.TaggedError("OpenRouterError")<{
+  message: string
+  cause?: unknown
+}> {}
 
 export class OpenRouterClientConfig
-  extends Effect.Service<OpenRouterClientConfig>()("@effect-native/openrouter/OpenRouterClientConfig", {
-    effect: Effect.gen(function*() {
+  extends ServiceMap.Service<OpenRouterClientConfig, OR.SDKOptions>()("@effect-native/openrouter/OpenRouterClientConfig")
+{
+  static layer = (config: OR.SDKOptions) =>
+    Layer.succeed(OpenRouterClientConfig)(config)
+
+  static Default = Layer.effect(
+    OpenRouterClientConfig,
+    Effect.gen(function*() {
       const apiKey = yield* Config.string("OPENROUTER_API_KEY")
       const serverURL = yield* Config.string("OPENROUTER_BASE_URL").pipe(
         Config.withDefault("https://openrouter.ai/api/v1")
       )
       return { apiKey, serverURL } as OR.SDKOptions
     })
-  })
-{
-  static layer = (config: OR.SDKOptions) =>
-    Layer.succeed(
-      OpenRouterClientConfig, //
-      OpenRouterClientConfig.make(config)
-    )
+  )
 }
 
-export class OpenRouter extends Effect.Service<OpenRouter>()("@effect-native/openrouter/OpenRouter", {
-  dependencies: [OpenRouterClientConfig.Default],
-  effect: Effect.gen(function*() {
-    const config = yield* OpenRouterClientConfig
-    const openrouter = yield* Effect.try({
-      try: () => new OR.OpenRouter(config),
-      catch: (cause) => new OpenRouterError({ message: "Failed to create OpenRouter client", cause })
-    })
+interface OpenRouterService {
+  readonly client: OR.OpenRouter
+  readonly callModel: <const TTools extends ReadonlyArray<OR.Tool>>(
+    request: OR.CallModelInput<TTools>
+  ) => Effect.Effect<{
+    readonly result: OR.CallModelResult<TTools>
+    readonly reasoningStream: Effect.Effect<Stream.Stream<string, OpenRouterError>, OpenRouterError>
+    readonly newMessagesStream: Effect.Effect<Stream.Stream<OR.CallModelResult.Message, OpenRouterError>, OpenRouterError>
+    readonly toolStream: Effect.Effect<Stream.Stream<OR.CallModelResult.ToolCall, OpenRouterError>, OpenRouterError>
+    readonly toolCalls: Effect.Effect<ReadonlyArray<OR.CallModelResult.ToolCall>, OpenRouterError>
+    readonly toolCallsStream: Effect.Effect<
+      Stream.Stream<OR.CallModelResult.ToolCall, OpenRouterError>,
+      OpenRouterError
+    >
+    readonly response: Effect.Effect<OR.CallModelResult.Response, OpenRouterError>
+    readonly fullResponsesStream: Effect.Effect<
+      Stream.Stream<OR.CallModelResult.Response, OpenRouterError>,
+      OpenRouterError
+    >
+    readonly text: Effect.Effect<string, OpenRouterError>
+    readonly textStream: Effect.Effect<Stream.Stream<string, OpenRouterError>, OpenRouterError>
+    readonly cancel: Effect.Effect<void, OpenRouterError>
+  }, OpenRouterError>
+  readonly chat: (request: ChatRequest) => Effect.Effect<ChatResponse, OpenRouterError>
+}
 
-    const callModel = Effect.fn(function*<const TTools extends ReadonlyArray<OR.Tool>>(
-      request: OR.CallModelInput<TTools>
-    ) {
-      const result = yield* Effect.try({
-        try: () => openrouter.callModel(request),
-        catch: (cause) => new OpenRouterError({ cause, message: "Failed to callModel" })
-      })
-      yield* Effect.addFinalizer(() => cancel.pipe(Effect.ignore))
-
-      const text = Effect.tryPromise({
-        try: () => result.getText(),
-        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getText" })
-      })
-      const response = Effect.tryPromise({
-        try: () => result.getResponse(),
-        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getResponse" })
-      })
-      const toolCalls = Effect.tryPromise({
-        try: () => result.getToolCalls(),
-        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getToolCalls" })
-      })
-      const cancel = Effect.tryPromise({
-        try: () => result.cancel(),
-        catch: (cause) => new OpenRouterError({ cause, message: "Failed to cancel" })
+export class OpenRouter
+  extends ServiceMap.Service<OpenRouter, OpenRouterService>()("@effect-native/openrouter/OpenRouter")
+{
+  static DefaultWithoutDependencies = Layer.effect(
+    OpenRouter,
+    Effect.gen(function*() {
+      const config = yield* OpenRouterClientConfig
+      const openrouter = yield* Effect.try({
+        try: () => new OR.OpenRouter(config),
+        catch: (cause) => new OpenRouterError({ message: "Failed to create OpenRouter client", cause })
       })
 
-      const fullResponsesStream = Effect.try({
-        try: () => result.getFullResponsesStream(),
-        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getFullResponsesStream" })
-      }).pipe(
-        Effect.map((stream) =>
-          Stream.fromAsyncIterable(
-            stream,
-            (cause) => new OpenRouterError({ cause, message: "Error during getFullResponsesStream" })
+      const callModel = Effect.fn(function*<const TTools extends ReadonlyArray<OR.Tool>>(
+        request: OR.CallModelInput<TTools>
+      ) {
+        const result = yield* Effect.try({
+          try: () => openrouter.callModel(request),
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to callModel" })
+        })
+        yield* Effect.addFinalizer(() => cancel.pipe(Effect.ignore))
+
+        const text = Effect.tryPromise({
+          try: () => result.getText(),
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to getText" })
+        })
+        const response = Effect.tryPromise({
+          try: () => result.getResponse(),
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to getResponse" })
+        })
+        const toolCalls = Effect.tryPromise({
+          try: () => result.getToolCalls(),
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to getToolCalls" })
+        })
+        const cancel = Effect.tryPromise({
+          try: () => result.cancel(),
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to cancel" })
+        })
+
+        const fullResponsesStream = Effect.try({
+          try: () => result.getFullResponsesStream(),
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to getFullResponsesStream" })
+        }).pipe(
+          Effect.map((stream) =>
+            Stream.fromAsyncIterable(
+              stream,
+              (cause) => new OpenRouterError({ cause, message: "Error during getFullResponsesStream" })
+            )
           )
         )
-      )
-      const textStream = Effect.try({
-        try: () => result.getTextStream(),
-        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getTextStream" })
-      }).pipe(
-        Effect.map((stream) =>
-          Stream.fromAsyncIterable(
-            stream,
-            (cause) => new OpenRouterError({ cause, message: "Error during TextStream" })
+        const textStream = Effect.try({
+          try: () => result.getTextStream(),
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to getTextStream" })
+        }).pipe(
+          Effect.map((stream) =>
+            Stream.fromAsyncIterable(
+              stream,
+              (cause) => new OpenRouterError({ cause, message: "Error during TextStream" })
+            )
           )
         )
-      )
-      const newMessagesStream = Effect.try({
-        try: () => result.getNewMessagesStream(),
-        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getNewMessagesStream" })
-      }).pipe(
-        Effect.map((stream) =>
-          Stream.fromAsyncIterable(
-            stream,
-            (cause) => new OpenRouterError({ cause, message: "Error during NewMessagesStream" })
+        const newMessagesStream = Effect.try({
+          try: () => result.getNewMessagesStream(),
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to getNewMessagesStream" })
+        }).pipe(
+          Effect.map((stream) =>
+            Stream.fromAsyncIterable(
+              stream,
+              (cause) => new OpenRouterError({ cause, message: "Error during NewMessagesStream" })
+            )
           )
         )
-      )
-      const reasoningStream = Effect.try({
-        try: () => result.getReasoningStream(),
-        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getReasoningStream" })
-      }).pipe(
-        Effect.map((stream) =>
-          Stream.fromAsyncIterable(
-            stream,
-            (cause) => new OpenRouterError({ cause, message: "Error during ReasoningStream" })
+        const reasoningStream = Effect.try({
+          try: () => result.getReasoningStream(),
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to getReasoningStream" })
+        }).pipe(
+          Effect.map((stream) =>
+            Stream.fromAsyncIterable(
+              stream,
+              (cause) => new OpenRouterError({ cause, message: "Error during ReasoningStream" })
+            )
           )
         )
-      )
-      const toolStream = Effect.try({
-        try: () => result.getToolStream(),
-        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getToolStream" })
-      }).pipe(
-        Effect.map((stream) =>
-          Stream.fromAsyncIterable(
-            stream,
-            (cause) => new OpenRouterError({ cause, message: "Error during ToolStream" })
+        const toolStream = Effect.try({
+          try: () => result.getToolStream(),
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to getToolStream" })
+        }).pipe(
+          Effect.map((stream) =>
+            Stream.fromAsyncIterable(
+              stream,
+              (cause) => new OpenRouterError({ cause, message: "Error during ToolStream" })
+            )
           )
         )
-      )
-      const toolCallsStream = Effect.try({
-        try: () => result.getToolCallsStream(),
-        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getToolCallsStream" })
-      }).pipe(
-        Effect.map((stream) =>
-          Stream.fromAsyncIterable(
-            stream,
-            (cause) => new OpenRouterError({ cause, message: "Error during ToolCallsStream" })
+        const toolCallsStream = Effect.try({
+          try: () => result.getToolCallsStream(),
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to getToolCallsStream" })
+        }).pipe(
+          Effect.map((stream) =>
+            Stream.fromAsyncIterable(
+              stream,
+              (cause) => new OpenRouterError({ cause, message: "Error during ToolCallsStream" })
+            )
           )
         )
-      )
+
+        return {
+          result,
+
+          reasoningStream,
+          newMessagesStream,
+
+          toolStream,
+          toolCalls,
+          toolCallsStream,
+
+          response,
+          fullResponsesStream,
+
+          text,
+          textStream,
+
+          cancel
+        } as const
+      })
+
+      /** Simple chat completion that bypasses SDK response validation (workaround for SDK bug) */
+      const chat = (request: ChatRequest) =>
+        Effect.gen(function*() {
+          const response = yield* Effect.tryPromise({
+            try: () =>
+              fetch(`${config.serverURL}/chat/completions`, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  "Authorization": `Bearer ${config.apiKey}`
+                },
+                body: JSON.stringify(request)
+              }),
+            catch: (cause) => new OpenRouterError({ cause, message: "Failed to fetch chat completion" })
+          })
+
+          if (!response.ok) {
+            const errorText = yield* Effect.tryPromise({
+              try: () => response.text(),
+              catch: () => "Unknown error"
+            })
+            return yield* new OpenRouterError({ message: `OpenRouter API error (${response.status}): ${errorText}` })
+          }
+
+          const json = yield* Effect.tryPromise({
+            try: () => response.json() as Promise<ChatResponse>,
+            catch: (cause) => new OpenRouterError({ cause, message: "Failed to parse response JSON" })
+          })
+
+          return json
+        })
 
       return {
-        result,
-
-        reasoningStream,
-        newMessagesStream,
-
-        toolStream,
-        toolCalls,
-        toolCallsStream,
-
-        response,
-        fullResponsesStream,
-
-        text,
-        textStream,
-
-        cancel
+        client: openrouter,
+        callModel,
+        chat
       } as const
     })
+  )
 
-    /** Simple chat completion that bypasses SDK response validation (workaround for SDK bug) */
-    const chat = (request: ChatRequest) =>
-      Effect.gen(function*() {
-        const response = yield* Effect.tryPromise({
-          try: () =>
-            fetch(`${config.serverURL}/chat/completions`, {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                "Authorization": `Bearer ${config.apiKey}`
-              },
-              body: JSON.stringify(request)
-            }),
-          catch: (cause) => new OpenRouterError({ cause, message: "Failed to fetch chat completion" })
-        })
-
-        if (!response.ok) {
-          const errorText = yield* Effect.tryPromise({
-            try: () => response.text(),
-            catch: () => "Unknown error"
-          })
-          return yield* new OpenRouterError({ message: `OpenRouter API error (${response.status}): ${errorText}` })
-        }
-
-        const json = yield* Effect.tryPromise({
-          try: () => response.json() as Promise<ChatResponse>,
-          catch: (cause) => new OpenRouterError({ cause, message: "Failed to parse response JSON" })
-        })
-
-        return json
-      })
-
-    return {
-      client: openrouter,
-      callModel,
-      chat
-    } as const
-  })
-}) {
   static layer = (config: OR.SDKOptions) =>
     OpenRouter.DefaultWithoutDependencies.pipe(Layer.provideMerge(OpenRouterClientConfig.layer(config)))
 }

--- a/packages-native/openrouter/src/index.ts
+++ b/packages-native/openrouter/src/index.ts
@@ -1,0 +1,208 @@
+import * as OR from "@openrouter/sdk"
+import { Config, Effect, Layer, Schema, Stream } from "effect"
+
+/** Simple chat completion request (workaround for SDK response validation bug) */
+export interface ChatRequest {
+  model: string
+  messages: Array<{ role: "user" | "assistant" | "system"; content: string }>
+  temperature?: number
+  max_tokens?: number
+}
+
+/** Simple chat completion response */
+export interface ChatResponse {
+  id: string
+  choices: Array<{
+    message: { role: string; content: string }
+    finish_reason: string
+  }>
+  usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number }
+}
+
+export class OpenRouterError extends Schema.TaggedError<OpenRouterError>()("OpenRouterError", {
+  message: Schema.String,
+  cause: Schema.Defect.pipe(Schema.optional)
+}) {}
+
+export class OpenRouterClientConfig
+  extends Effect.Service<OpenRouterClientConfig>()("@effect-native/openrouter/OpenRouterClientConfig", {
+    effect: Effect.gen(function*() {
+      const apiKey = yield* Config.string("OPENROUTER_API_KEY")
+      const serverURL = yield* Config.string("OPENROUTER_BASE_URL").pipe(
+        Config.withDefault("https://openrouter.ai/api/v1")
+      )
+      return { apiKey, serverURL } as OR.SDKOptions
+    })
+  })
+{
+  static layer = (config: OR.SDKOptions) =>
+    Layer.succeed(
+      OpenRouterClientConfig, //
+      OpenRouterClientConfig.make(config)
+    )
+}
+
+export class OpenRouter extends Effect.Service<OpenRouter>()("@effect-native/openrouter/OpenRouter", {
+  dependencies: [OpenRouterClientConfig.Default],
+  effect: Effect.gen(function*() {
+    const config = yield* OpenRouterClientConfig
+    const openrouter = yield* Effect.try({
+      try: () => new OR.OpenRouter(config),
+      catch: (cause) => new OpenRouterError({ message: "Failed to create OpenRouter client", cause })
+    })
+
+    const callModel = Effect.fn(function*<const TTools extends ReadonlyArray<OR.Tool>>(
+      request: OR.CallModelInput<TTools>
+    ) {
+      const result = yield* Effect.try({
+        try: () => openrouter.callModel(request),
+        catch: (cause) => new OpenRouterError({ cause, message: "Failed to callModel" })
+      })
+      yield* Effect.addFinalizer(() => cancel.pipe(Effect.ignore))
+
+      const text = Effect.tryPromise({
+        try: () => result.getText(),
+        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getText" })
+      })
+      const response = Effect.tryPromise({
+        try: () => result.getResponse(),
+        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getResponse" })
+      })
+      const toolCalls = Effect.tryPromise({
+        try: () => result.getToolCalls(),
+        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getToolCalls" })
+      })
+      const cancel = Effect.tryPromise({
+        try: () => result.cancel(),
+        catch: (cause) => new OpenRouterError({ cause, message: "Failed to cancel" })
+      })
+
+      const fullResponsesStream = Effect.try({
+        try: () => result.getFullResponsesStream(),
+        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getFullResponsesStream" })
+      }).pipe(
+        Effect.map((stream) =>
+          Stream.fromAsyncIterable(
+            stream,
+            (cause) => new OpenRouterError({ cause, message: "Error during getFullResponsesStream" })
+          )
+        )
+      )
+      const textStream = Effect.try({
+        try: () => result.getTextStream(),
+        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getTextStream" })
+      }).pipe(
+        Effect.map((stream) =>
+          Stream.fromAsyncIterable(
+            stream,
+            (cause) => new OpenRouterError({ cause, message: "Error during TextStream" })
+          )
+        )
+      )
+      const newMessagesStream = Effect.try({
+        try: () => result.getNewMessagesStream(),
+        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getNewMessagesStream" })
+      }).pipe(
+        Effect.map((stream) =>
+          Stream.fromAsyncIterable(
+            stream,
+            (cause) => new OpenRouterError({ cause, message: "Error during NewMessagesStream" })
+          )
+        )
+      )
+      const reasoningStream = Effect.try({
+        try: () => result.getReasoningStream(),
+        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getReasoningStream" })
+      }).pipe(
+        Effect.map((stream) =>
+          Stream.fromAsyncIterable(
+            stream,
+            (cause) => new OpenRouterError({ cause, message: "Error during ReasoningStream" })
+          )
+        )
+      )
+      const toolStream = Effect.try({
+        try: () => result.getToolStream(),
+        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getToolStream" })
+      }).pipe(
+        Effect.map((stream) =>
+          Stream.fromAsyncIterable(
+            stream,
+            (cause) => new OpenRouterError({ cause, message: "Error during ToolStream" })
+          )
+        )
+      )
+      const toolCallsStream = Effect.try({
+        try: () => result.getToolCallsStream(),
+        catch: (cause) => new OpenRouterError({ cause, message: "Failed to getToolCallsStream" })
+      }).pipe(
+        Effect.map((stream) =>
+          Stream.fromAsyncIterable(
+            stream,
+            (cause) => new OpenRouterError({ cause, message: "Error during ToolCallsStream" })
+          )
+        )
+      )
+
+      return {
+        result,
+
+        reasoningStream,
+        newMessagesStream,
+
+        toolStream,
+        toolCalls,
+        toolCallsStream,
+
+        response,
+        fullResponsesStream,
+
+        text,
+        textStream,
+
+        cancel
+      } as const
+    })
+
+    /** Simple chat completion that bypasses SDK response validation (workaround for SDK bug) */
+    const chat = (request: ChatRequest) =>
+      Effect.gen(function*() {
+        const response = yield* Effect.tryPromise({
+          try: () =>
+            fetch(`${config.serverURL}/chat/completions`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Bearer ${config.apiKey}`
+              },
+              body: JSON.stringify(request)
+            }),
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to fetch chat completion" })
+        })
+
+        if (!response.ok) {
+          const errorText = yield* Effect.tryPromise({
+            try: () => response.text(),
+            catch: () => "Unknown error"
+          })
+          return yield* new OpenRouterError({ message: `OpenRouter API error (${response.status}): ${errorText}` })
+        }
+
+        const json = yield* Effect.tryPromise({
+          try: () => response.json() as Promise<ChatResponse>,
+          catch: (cause) => new OpenRouterError({ cause, message: "Failed to parse response JSON" })
+        })
+
+        return json
+      })
+
+    return {
+      client: openrouter,
+      callModel,
+      chat
+    } as const
+  })
+}) {
+  static layer = (config: OR.SDKOptions) =>
+    OpenRouter.DefaultWithoutDependencies.pipe(Layer.provideMerge(OpenRouterClientConfig.layer(config)))
+}

--- a/packages-native/openrouter/test/callModel.test.ts
+++ b/packages-native/openrouter/test/callModel.test.ts
@@ -1,0 +1,223 @@
+import { assert, describe, it } from "@effect/vitest"
+import * as OR from "@openrouter/sdk"
+import { Effect, Layer } from "effect"
+import { OpenRouter, OpenRouterClientConfig } from "../src/index.js"
+
+/**
+ * Creates a mock HTTPClient with a custom fetcher that returns predefined responses.
+ * This allows testing OpenRouter without making real API calls.
+ */
+function createMockHttpClient(mockFetch: typeof globalThis.fetch) {
+  return new OR.HTTPClient({
+    fetcher: mockFetch
+  })
+}
+
+/**
+ * Real SSE response captured from OpenRouter API via the dev-fetch-cache.
+ * This is what the API actually returns for a simple "say hello" request.
+ */
+const REAL_SSE_RESPONSE_JSONL =
+  `{"json":{"type":"response.created","response":{"object":"response","id":"gen-1766801159-e9nTRO0vtJdg1Gc8Vsv9","created_at":1766801159,"status":"in_progress","error":null,"output_text":"","output":[],"model":"openai/gpt-4o","incomplete_details":null,"max_tool_calls":null,"tools":[],"tool_choice":"auto","parallel_tool_calls":true,"max_output_tokens":null,"temperature":null,"top_p":null,"metadata":{},"background":false,"previous_response_id":null,"service_tier":"auto","truncation":null,"store":false,"instructions":null,"reasoning":null,"safety_identifier":null,"prompt_cache_key":null,"user":null},"sequence_number":0}}
+{"json":{"type":"response.in_progress","response":{"object":"response","id":"gen-1766801159-e9nTRO0vtJdg1Gc8Vsv9","created_at":1766801159,"status":"in_progress","error":null,"output_text":"","output":[],"model":"openai/gpt-4o","incomplete_details":null,"max_tool_calls":null,"tools":[],"tool_choice":"auto","parallel_tool_calls":true,"max_output_tokens":null,"temperature":null,"top_p":null,"metadata":{},"background":false,"previous_response_id":null,"service_tier":"auto","truncation":null,"store":false,"instructions":null,"reasoning":null,"safety_identifier":null,"prompt_cache_key":null,"user":null},"sequence_number":1}}
+{"json":{"type":"response.output_item.added","output_index":0,"item":{"type":"message","status":"in_progress","content":[],"id":"msg_tmp_qife5pjb33c","role":"assistant"},"sequence_number":2}}
+{"json":{"type":"response.content_part.added","item_id":"msg_tmp_qife5pjb33c","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"text":""},"sequence_number":3}}
+{"json":{"type":"response.output_text.delta","logprobs":[],"output_index":0,"item_id":"msg_tmp_qife5pjb33c","content_index":0,"delta":"Hello","sequence_number":4}}
+{"json":{"type":"response.output_text.delta","logprobs":[],"output_index":0,"item_id":"msg_tmp_qife5pjb33c","content_index":0,"delta":"!","sequence_number":5}}
+{"json":{"type":"response.output_text.delta","logprobs":[],"output_index":0,"item_id":"msg_tmp_qife5pjb33c","content_index":0,"delta":" How","sequence_number":6}}
+{"json":{"type":"response.output_text.delta","logprobs":[],"output_index":0,"item_id":"msg_tmp_qife5pjb33c","content_index":0,"delta":" can","sequence_number":7}}
+{"json":{"type":"response.output_text.delta","logprobs":[],"output_index":0,"item_id":"msg_tmp_qife5pjb33c","content_index":0,"delta":" I","sequence_number":8}}
+{"json":{"type":"response.output_text.delta","logprobs":[],"output_index":0,"item_id":"msg_tmp_qife5pjb33c","content_index":0,"delta":" assist","sequence_number":9}}
+{"json":{"type":"response.output_text.delta","logprobs":[],"output_index":0,"item_id":"msg_tmp_qife5pjb33c","content_index":0,"delta":" you","sequence_number":10}}
+{"json":{"type":"response.output_text.delta","logprobs":[],"output_index":0,"item_id":"msg_tmp_qife5pjb33c","content_index":0,"delta":" today","sequence_number":11}}
+{"json":{"type":"response.output_text.delta","logprobs":[],"output_index":0,"item_id":"msg_tmp_qife5pjb33c","content_index":0,"delta":"?","sequence_number":12}}
+{"json":{"type":"response.output_text.done","item_id":"msg_tmp_qife5pjb33c","output_index":0,"content_index":0,"text":"Hello! How can I assist you today?","logprobs":[],"sequence_number":13}}
+{"json":{"type":"response.content_part.done","item_id":"msg_tmp_qife5pjb33c","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"text":"Hello! How can I assist you today?"},"sequence_number":14}}
+{"json":{"type":"response.output_item.done","output_index":0,"item":{"type":"message","status":"completed","content":[{"type":"output_text","text":"Hello! How can I assist you today?","annotations":[]}],"id":"msg_tmp_qife5pjb33c","role":"assistant"},"sequence_number":15}}
+{"json":{"type":"response.completed","response":{"object":"response","id":"gen-1766801159-e9nTRO0vtJdg1Gc8Vsv9","created_at":1766801159,"model":"openai/gpt-4o","status":"completed","output":[{"type":"message","status":"completed","content":[{"type":"output_text","text":"Hello! How can I assist you today?","annotations":[]}],"id":"msg_tmp_qife5pjb33c","role":"assistant"}],"output_text":"","error":null,"incomplete_details":null,"usage":{"input_tokens":9,"input_tokens_details":{"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":18,"cost":0.0001125,"is_byok":false,"cost_details":{"upstream_inference_cost":null,"upstream_inference_input_cost":0.0000225,"upstream_inference_output_cost":0.00009}},"max_tool_calls":null,"tools":[],"tool_choice":"auto","parallel_tool_calls":true,"max_output_tokens":null,"temperature":null,"top_p":null,"metadata":{},"background":false,"previous_response_id":null,"service_tier":"auto","truncation":null,"store":false,"instructions":null,"reasoning":null,"safety_identifier":null,"prompt_cache_key":null,"user":null},"sequence_number":16}}
+{"text":"[DONE]"}`
+
+type JsonlRecord = { json: unknown } | { text: string } | { comment: string } | { delay_ms: number }
+
+interface TimedChunk {
+  data: string
+  delay_ms: number
+}
+
+/**
+ * Parse JSONL format to TimedChunk array.
+ * Ported from dev-fetch-cache/src/sse-handler.ts jsonlToTimedChunks
+ */
+function jsonlToTimedChunks(jsonl: string): Array<TimedChunk> {
+  const lines = jsonl.split("\n").filter((line) => line.trim().length > 0)
+  const chunks: Array<TimedChunk> = []
+  let pendingDelay = 0
+
+  for (const line of lines) {
+    const parsed = JSON.parse(line) as JsonlRecord
+
+    // Handle timing lines
+    if ("delay_ms" in parsed) {
+      pendingDelay = parsed.delay_ms
+      continue
+    }
+
+    // Handle {json: ...}
+    if ("json" in parsed) {
+      chunks.push({
+        data: `data: ${JSON.stringify(parsed.json)}\n\n`,
+        delay_ms: pendingDelay
+      })
+      pendingDelay = 0
+      continue
+    }
+
+    // Handle {text: ...}
+    if ("text" in parsed) {
+      chunks.push({
+        data: `data: ${parsed.text}\n\n`,
+        delay_ms: pendingDelay
+      })
+      pendingDelay = 0
+      continue
+    }
+
+    // Handle {comment: ...}
+    if ("comment" in parsed) {
+      chunks.push({
+        data: parsed.comment,
+        delay_ms: pendingDelay
+      })
+      pendingDelay = 0
+      continue
+    }
+  }
+
+  return chunks
+}
+
+/**
+ * Replay TimedChunks as a ReadableStream (without actual delays for testing).
+ * Ported from dev-fetch-cache/src/sse-handler.ts replayStreamWithTiming
+ */
+function replayStreamWithoutTiming(timedChunks: Array<TimedChunk>): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder()
+  let chunkIndex = 0
+
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (chunkIndex >= timedChunks.length) {
+        controller.close()
+        return
+      }
+
+      const chunk = timedChunks[chunkIndex]!
+      controller.enqueue(encoder.encode(chunk.data))
+      chunkIndex++
+    }
+  })
+}
+
+/**
+ * Create a mock SSE Response from JSONL cache data.
+ */
+function createMockSSEResponse(jsonl: string): Response {
+  const timedChunks = jsonlToTimedChunks(jsonl)
+  const stream = replayStreamWithoutTiming(timedChunks)
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream"
+    }
+  })
+}
+
+describe("OpenRouter.callModel", () => {
+  it("returns text from a mocked streaming response", async () => {
+    const mockHttpClient = createMockHttpClient(async (_request) => {
+      return createMockSSEResponse(REAL_SSE_RESPONSE_JSONL)
+    })
+
+    const testLayer = OpenRouter.DefaultWithoutDependencies.pipe(
+      Layer.provideMerge(
+        OpenRouterClientConfig.layer({
+          apiKey: "mock-api-key",
+          httpClient: mockHttpClient
+        })
+      )
+    )
+
+    const result = await Effect.gen(function*() {
+      const openrouter = yield* OpenRouter
+      const callResult = yield* openrouter.callModel({
+        model: "openai/gpt-4o",
+        input: "say hello"
+      })
+      return yield* callResult.text
+    }).pipe(Effect.scoped, Effect.provide(testLayer), Effect.runPromise)
+
+    assert.strictEqual(result, "Hello! How can I assist you today?")
+  })
+
+  it("returns response metadata including id", async () => {
+    const mockHttpClient = createMockHttpClient(async (_request) => {
+      return createMockSSEResponse(REAL_SSE_RESPONSE_JSONL)
+    })
+
+    const testLayer = OpenRouter.DefaultWithoutDependencies.pipe(
+      Layer.provideMerge(
+        OpenRouterClientConfig.layer({
+          apiKey: "mock-api-key",
+          httpClient: mockHttpClient
+        })
+      )
+    )
+
+    const response = await Effect.gen(function*() {
+      const openrouter = yield* OpenRouter
+      const callResult = yield* openrouter.callModel({
+        model: "openai/gpt-4o",
+        input: "say hello"
+      })
+      return yield* callResult.response
+    }).pipe(Effect.scoped, Effect.provide(testLayer), Effect.runPromise)
+
+    assert.strictEqual(response.id, "gen-1766801159-e9nTRO0vtJdg1Gc8Vsv9")
+    assert.strictEqual(response.model, "openai/gpt-4o")
+    assert.strictEqual(response.status, "completed")
+  })
+
+  it("passes the request to the mock fetcher with correct auth header", async () => {
+    let capturedRequest: Request
+
+    const mockHttpClient = createMockHttpClient(async (request) => {
+      if (request && typeof request === "object" && "clone" in request) {
+        capturedRequest = request.clone()
+      }
+      return createMockSSEResponse(REAL_SSE_RESPONSE_JSONL)
+    })
+
+    const testLayer = OpenRouter.DefaultWithoutDependencies.pipe(
+      Layer.provideMerge(
+        OpenRouterClientConfig.layer({
+          apiKey: "test-api-key-12345",
+          httpClient: mockHttpClient
+        })
+      )
+    )
+
+    await Effect.gen(function*() {
+      const openrouter = yield* OpenRouter
+      const callResult = yield* openrouter.callModel({
+        model: "anthropic/claude-3-opus",
+        input: "Test message"
+      })
+      return yield* callResult.text
+    }).pipe(Effect.scoped, Effect.provide(testLayer), Effect.runPromise)
+
+    const body = await capturedRequest!.json()
+    assert.strictEqual(body.model, "anthropic/claude-3-opus")
+    assert.include(capturedRequest!.headers.get("Authorization"), "test-api-key-12345")
+  })
+})

--- a/packages-native/openrouter/tsconfig.build.json
+++ b/packages-native/openrouter/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {
+    "outDir": "build/esm",
+    "declarationDir": "build/dts",
+    "rootDir": "src"
+  },
+  "references": []
+}

--- a/packages-native/openrouter/tsconfig.json
+++ b/packages-native/openrouter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [],
+  "references": [
+    { "path": "tsconfig.src.json" },
+    { "path": "tsconfig.test.json" }
+  ]
+}

--- a/packages-native/openrouter/tsconfig.src.json
+++ b/packages-native/openrouter/tsconfig.src.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {
+    "outDir": "build/src",
+    "rootDir": "src"
+  },
+  "references": []
+}

--- a/packages-native/openrouter/tsconfig.test.json
+++ b/packages-native/openrouter/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["test/**/*.test.ts"],
+  "compilerOptions": {
+    "outDir": "build/test",
+    "rootDir": "test"
+  },
+  "references": [
+    { "path": "tsconfig.src.json" }
+  ]
+}

--- a/packages-native/openrouter/vitest.config.ts
+++ b/packages-native/openrouter/vitest.config.ts
@@ -1,0 +1,6 @@
+import { mergeConfig, type ViteUserConfig } from "vitest/config"
+import shared from "../../vitest.shared.ts"
+
+const config: ViteUserConfig = {}
+
+export default mergeConfig(shared, config)


### PR DESCRIPTION
## Summary

Updates `@effect-native/openrouter` for Effect v4 compatibility.

- `peerDependencies.effect`: `^3.19.0` → `^4.0.0-beta.0`
- `devDependencies.effect`: `latest` → `beta`
- `devDependencies.@effect/vitest`: `latest` → `beta`

Stacked on #221 (root resolutions update).