### PR TITLE
chore(tui-testing-library): update effect deps to beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "resolutions": {
     "autolinker": "^3.16.2",
-    "effect": "latest",
+    "effect": "beta",
     "dependency-tree": "^10.0.9",
     "detective-amd": "^5.0.2",
     "detective-cjs": "^5.0.1",
@@ -49,7 +49,7 @@
     "@effect/docgen": "^0.5.2",
     "@effect/eslint-plugin": "^0.3.2",
     "@effect/language-service": "^0.23.5",
-    "@effect/vitest": "latest",
+    "@effect/vitest": "beta",
     "@eslint/compat": "^1.3.2",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.39.2",

--- a/packages-native/tui-testing-library/package.json
+++ b/packages-native/tui-testing-library/package.json
@@ -40,7 +40,7 @@
     "coverage": "bun test --coverage"
   },
   "peerDependencies": {
-    "effect": "^3.19.0"
+    "effect": "^4.0.0-beta.0"
   },
   "dependencies": {
     "@happy-dom/global-registrator": "^20.0.11",
@@ -48,8 +48,8 @@
   },
   "devDependencies": {
     "@effect-native/bun-test": "workspace:*",
-    "@effect/vitest": "latest",
+    "@effect/vitest": "beta",
     "@types/bun": "latest",
-    "effect": "latest"
+    "effect": "beta"
   }
 }


### PR DESCRIPTION
## Summary

Updates `@effect-native/tui-testing-library` for Effect v4 compatibility.

- `peerDependencies.effect`: `^3.19.0` → `^4.0.0-beta.0`
- `devDependencies.effect`: `latest` → `beta`
- `devDependencies.@effect/vitest`: `latest` → `beta`

Stacked on #221 (root resolutions update).