### PR TITLE
chore(libcrsql): migrate to effect@beta

### DIFF
--- a/packages-native/libcrsql/package.json
+++ b/packages-native/libcrsql/package.json
@@ -40,14 +40,10 @@
     "coverage": "vitest --coverage"
   },
   "peerDependencies": {
-    "effect": "^3.19.0",
-    "@effect/platform": "*"
+    "effect": "^4.0.0-beta.0"
   },
   "peerDependenciesMeta": {
     "effect": {
-      "optional": true
-    },
-    "@effect/platform": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         version: 0.23.5
       '@effect/vitest':
         specifier: beta
-        version: 4.0.0-beta.6(effect@4.0.0-beta.6)(vitest@3.2.4)
+        version: 4.0.0-beta.6(effect@4.0.0-beta.8)(vitest@3.2.4)
       '@eslint/compat':
         specifier: ^1.3.2
         version: 1.4.1(eslint@9.39.2)
@@ -290,9 +290,6 @@ importers:
 
   packages-native/libcrsql:
     dependencies:
-      '@effect/platform':
-        specifier: '*'
-        version: 0.93.5(effect@4.0.0-beta.6)
       effect:
         specifier: beta
         version: 4.0.0-beta.6
@@ -304,6 +301,22 @@ importers:
         specifier: beta
         version: 4.0.0-beta.6
     publishDirectory: dist
+
+  packages-native/name-checker:
+    dependencies:
+      '@effect-native/fetch-hooks':
+        specifier: workspace:*
+        version: link:../fetch-hooks
+      '@effect-native/openrouter':
+        specifier: workspace:*
+        version: link:../openrouter
+    devDependencies:
+      effect:
+        specifier: beta
+        version: 4.0.0-beta.8
+      tsx:
+        specifier: latest
+        version: 4.21.0
 
   packages-native/note:
     dependencies:
@@ -326,6 +339,20 @@ importers:
       '@effect/vitest':
         specifier: latest
         version: 0.27.0(effect@4.0.0-beta.6)(vitest@3.2.4)
+    publishDirectory: dist
+
+  packages-native/openrouter:
+    dependencies:
+      '@openrouter/sdk':
+        specifier: ^0.3.10
+        version: 0.3.16
+      effect:
+        specifier: beta
+        version: 4.0.0-beta.8
+    devDependencies:
+      '@effect/vitest':
+        specifier: beta
+        version: 4.0.0-beta.8(effect@4.0.0-beta.8)(vitest@3.2.4)
     publishDirectory: dist
 
   packages-native/opentui-dom:
@@ -390,8 +417,8 @@ importers:
         version: 4.0.0-beta.6
     devDependencies:
       '@effect/vitest':
-        specifier: latest
-        version: 0.27.0(effect@4.0.0-beta.6)(vitest@3.2.4)
+        specifier: beta
+        version: 4.0.0-beta.8(effect@4.0.0-beta.6)(vitest@3.2.4)
     publishDirectory: dist
 
   packages-native/schemas:
@@ -405,7 +432,11 @@ importers:
         version: 0.27.0(effect@4.0.0-beta.6)(vitest@3.2.4)
     publishDirectory: dist
 
-  packages-native/ssh-keep: {}
+  packages-native/ssh-keep:
+    dependencies:
+      effect:
+        specifier: beta
+        version: 4.0.0-beta.8
 
   packages-native/tui-testing-library:
     dependencies:
@@ -423,8 +454,8 @@ importers:
         specifier: workspace:*
         version: link:../bun-test
       '@effect/vitest':
-        specifier: latest
-        version: 0.27.0(effect@4.0.0-beta.6)(vitest@3.2.4)
+        specifier: beta
+        version: 4.0.0-beta.8(effect@4.0.0-beta.6)(vitest@3.2.4)
       '@types/bun':
         specifier: latest
         version: 1.3.5
@@ -1163,11 +1194,6 @@ packages:
       '@effect/sql': ^0.49.0
       effect: ^3.19.13
 
-  '@effect/platform@0.93.5':
-    resolution: {integrity: sha512-31ikgJRAG8py26SEIjyrgaPlEJ+JYqOsGP7g4WHFRIYxGFwFX/OrlBrW0+mRISCfeDR1BUztaFyIZyRPfBRvcw==}
-    peerDependencies:
-      effect: ^3.19.8
-
   '@effect/platform@0.94.1':
     resolution: {integrity: sha512-SlL8OMTogHmMNnFLnPAHHo3ua1yrB1LNQOVQMiZsqYu9g3216xjr0gn5WoDgCxUyOdZcseegMjWJ7dhm/2vnfg==}
     peerDependencies:
@@ -1331,6 +1357,12 @@ packages:
     resolution: {integrity: sha512-G9aEEgkX/kNgJVB/TRKzM+xAlsW6ryJ118XsYK6OW5QeVo9qcswrYobKYD0DrmyBVNOUIbSsx//9DfbswSGI9w==}
     peerDependencies:
       effect: ^4.0.0-beta.6
+      vitest: ^3.0.0
+
+  '@effect/vitest@4.0.0-beta.8':
+    resolution: {integrity: sha512-CnwGyFhEOaGWhEfTLtUSC8Yq1losYk+V6Aepc18um8NkOHnbr5fLClE+XqNFPO1DN6Ehs6Kv/ms3Di2kw9/9Kg==}
+    peerDependencies:
+      effect: ^4.0.0-beta.8
       vitest: ^3.0.0
 
   '@effect/wa-sqlite@0.1.2':
@@ -2040,6 +2072,9 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '>0.73.0'
+
+  '@openrouter/sdk@0.3.16':
+    resolution: {integrity: sha512-WEBlrXdc5R8I7o2temkMV65tIRGkzg9ct4DMNZ/FHS/hiRscLRS5EpcuORnAgjzZAh9X2dSsBpgygM8T7KiNAw==}
 
   '@opentelemetry/semantic-conventions@1.38.0':
     resolution: {integrity: sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==}
@@ -3627,6 +3662,9 @@ packages:
 
   effect@4.0.0-beta.6:
     resolution: {integrity: sha512-2xpzTi1f8eRYByMYso/vBiZGCvK74dVOMHOnXbwgzZQg6t5JaZ6ov7i5AU/vKPtb2y9FJbZwhf8owXBZq+LY0g==}
+
+  effect@4.0.0-beta.8:
+    resolution: {integrity: sha512-8Df3vdVY8ahZcn2oC27lAfMGXHId1I5YDHqGgLe4UCQ9D8Kzmb5oq+qZVXvmY9fZANabnu47AE41040kc52QCg==}
 
   electron-to-chromium@1.5.262:
     resolution: {integrity: sha512-NlAsMteRHek05jRUxUR0a5jpjYq9ykk6+kO0yRaMi5moe7u0fVIOeQ3Y30A8dIiWFBNUoQGi1ljb1i5VtS9WQQ==}
@@ -7460,13 +7498,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform@0.93.5(effect@4.0.0-beta.6)':
-    dependencies:
-      effect: 4.0.0-beta.6
-      find-my-way-ts: 0.1.6
-      msgpackr: 1.11.5
-      multipasta: 0.2.7
-
   '@effect/platform@0.94.1(effect@4.0.0-beta.6)':
     dependencies:
       effect: 4.0.0-beta.6
@@ -7631,10 +7662,20 @@ snapshots:
       effect: 4.0.0-beta.6
       vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.0.3)(@vitest/browser@3.2.4)(happy-dom@20.0.11)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@effect/vitest@4.0.0-beta.6(effect@4.0.0-beta.6)(vitest@3.2.4)':
+  '@effect/vitest@4.0.0-beta.6(effect@4.0.0-beta.8)(vitest@3.2.4)':
+    dependencies:
+      effect: 4.0.0-beta.8
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.3)(@vitest/browser@3.2.4)(happy-dom@20.0.11)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@effect/vitest@4.0.0-beta.8(effect@4.0.0-beta.6)(vitest@3.2.4)':
     dependencies:
       effect: 4.0.0-beta.6
-      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@22.19.3)(@vitest/browser@3.2.4)(happy-dom@20.0.11)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.0.3)(@vitest/browser@3.2.4)(happy-dom@20.0.11)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@effect/vitest@4.0.0-beta.8(effect@4.0.0-beta.8)(vitest@3.2.4)':
+    dependencies:
+      effect: 4.0.0-beta.8
+      vitest: 3.2.4(@edge-runtime/vm@5.0.0)(@types/debug@4.1.12)(@types/node@25.0.3)(@vitest/browser@3.2.4)(happy-dom@20.0.11)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@effect/wa-sqlite@0.1.2': {}
 
@@ -8309,6 +8350,10 @@ snapshots:
     dependencies:
       react: 19.2.0
       react-native: 0.82.1(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.0)
+
+  '@openrouter/sdk@0.3.16':
+    dependencies:
+      zod: 3.25.76
 
   '@opentelemetry/semantic-conventions@1.38.0': {}
 
@@ -9896,6 +9941,19 @@ snapshots:
   ee-first@1.1.1: {}
 
   effect@4.0.0-beta.6:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 4.5.3
+      find-my-way-ts: 0.1.6
+      ini: 6.0.0
+      kubernetes-types: 1.30.0
+      msgpackr: 1.11.8
+      multipasta: 0.2.7
+      toml: 3.0.0
+      uuid: 13.0.0
+      yaml: 2.8.2
+
+  effect@4.0.0-beta.8:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.5.3


### PR DESCRIPTION
## Summary

Migrates `@effect-native/libcrsql` to Effect v4.

- Removed `@effect/platform` from optional peerDependencies (merged into effect core)
- `effect` peer: `^3.19.0` → `^4.0.0-beta.0`
- No import migration needed: source files have no `@effect/platform` imports (only `effect` core is used)

## Verification

- `pnpm build` passes (6 files compiled, dist/lib copied)
- `pnpm test` passes (11 tests pass, 1 skipped — integration test requiring native binary)

Stacked on #221 (root resolutions update).