### PR TITLE
fix(release): publish from pre mode on v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "docgen": "bun scripts/docgen.mjs",
     "test-types": "tstyche",
     "changeset-version": "changeset version && bun scripts/force-libsqlite-embedded.mjs",
-    "changeset-publish-beta": "bun run codemod && bun run build && bun run test && changeset publish --tag beta --provenance && bun scripts/postpublish-dist-tags.mjs",
+    "changeset-publish-beta": "bun run codemod && bun run build && bun run test && changeset publish --provenance && bun scripts/postpublish-dist-tags.mjs",
     "changeset-publish": "bun run codemod && bun run build && bun run test && changeset publish --provenance && bun scripts/postpublish-dist-tags.mjs"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- remove the explicit `--tag beta` from `changeset-publish-beta`
- keep `changeset publish` in pre mode so release can publish prerelease versions
- unblock the v4 release workflow that failed with `Releasing under custom tag is not allowed in pre mode`