### PR TITLE
fix(sqlite-graph): publish from package root

### DIFF
--- a/packages/sqlite-graph-ext/package.json
+++ b/packages/sqlite-graph-ext/package.json
@@ -13,7 +13,7 @@
   "publishConfig": {
     "access": "public",
     "provenance": true,
-    "directory": "dist",
+    "directory": ".",
     "linkDirectory": false
   },
   "exports": {


### PR DESCRIPTION
## Summary
- switch `@effect-native/sqlite-graph` publish directory from `dist` to package root
- fix release failure where Changesets could not find `packages/sqlite-graph-ext/dist/package.json`
- keep existing package `files` filter so published contents remain scoped