### PR TITLE
Refresh Effect beta to 4.0.0-beta.99

### DIFF
--- a/.gaps/effect-refresh.md
+++ b/.gaps/effect-refresh.md
@@ -1,18 +1,21 @@
-# Effect Refresh Gap Snapshot — 2026-07-10
+# Effect Refresh Gap Snapshot — 2026-07-17
 
 ## Current evidence
 
 - Branch freshness: `v4-refresh` is rebased on `origin/v4` at `73087ca4`.
 - npm beta tags: `effect`, `@effect/platform-node`,
   `@effect/sql-sqlite-bun`, and `@effect/sql-sqlite-node` are all
-  `4.0.0-beta.97`.
-- Current lock resolution: all four packages are `4.0.0-beta.97`.
-- Reference checkout: effect-smol is fast-forwarded to `5946da38`; the local
+  `4.0.0-beta.99`.
+- Current lock resolution: all four packages are `4.0.0-beta.99`.
+- Reference checkout: effect-smol is fast-forwarded to `3a1128c7`; the local
   untracked `CLAUDE.md` is preserved.
 - Quality gates: `bun install --frozen-lockfile`, `bun run lint-fix`,
   `bun run docgen`, and `bun run ok` all exit `0`.
-- PR lifecycle: ready PR #282 is open from `v4-refresh` into `v4`.
+- Removed ServiceMap scan: no matches in active guidance or package code.
+- PR lifecycle: ready PR #282 remains the expected open refresh PR pending
+  push and body refresh.
 
 ## Gaps
 
-No active refresh gaps remain.
+The code and dependency gates are healthy. Review artifacts, push, and PR body
+refresh remain before handoff.

--- a/.gaps/effect-refresh.md
+++ b/.gaps/effect-refresh.md
@@ -12,10 +12,11 @@
 - Quality gates: `bun install --frozen-lockfile`, `bun run lint-fix`,
   `bun run docgen`, and `bun run ok` all exit `0`.
 - Removed ServiceMap scan: no matches in active guidance or package code.
-- PR lifecycle: ready PR #282 remains the expected open refresh PR pending
-  push and body refresh.
+- Review: adversarial verdict `APPROVE`; Thing Golf score `-1` for target
+  `5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035`.
+- PR lifecycle: ready PR #282 is the open refresh PR from `v4-refresh` into
+  `v4`; the refreshed branch and body carry the beta.99 evidence.
 
 ## Gaps
 
-The code and dependency gates are healthy. Review artifacts, push, and PR body
-refresh remain before handoff.
+No active refresh gaps remain.

--- a/.gaps/effect-refresh.md
+++ b/.gaps/effect-refresh.md
@@ -1,0 +1,18 @@
+# Effect Refresh Gap Snapshot — 2026-07-10
+
+## Current evidence
+
+- Branch freshness: `v4-refresh` is rebased on `origin/v4` at `73087ca4`.
+- npm beta tags: `effect`, `@effect/platform-node`,
+  `@effect/sql-sqlite-bun`, and `@effect/sql-sqlite-node` are all
+  `4.0.0-beta.97`.
+- Current lock resolution: all four packages are `4.0.0-beta.97`.
+- Reference checkout: effect-smol is fast-forwarded to `5946da38`; the local
+  untracked `CLAUDE.md` is preserved.
+- Quality gates: `bun install --frozen-lockfile`, `bun run lint-fix`,
+  `bun run docgen`, and `bun run ok` all exit `0`.
+- PR lifecycle: pending committed refresh.
+
+## Gaps
+
+1. Review, commit, push, and update or create the ready PR into `v4`.

--- a/.gaps/effect-refresh.md
+++ b/.gaps/effect-refresh.md
@@ -11,8 +11,8 @@
   untracked `CLAUDE.md` is preserved.
 - Quality gates: `bun install --frozen-lockfile`, `bun run lint-fix`,
   `bun run docgen`, and `bun run ok` all exit `0`.
-- PR lifecycle: pending committed refresh.
+- PR lifecycle: ready PR #282 is open from `v4-refresh` into `v4`.
 
 ## Gaps
 
-1. Review, commit, push, and update or create the ready PR into `v4`.
+No active refresh gaps remain.

--- a/.tasks/code-review/effect-native/v4-refresh/2a81df063a46bec15bf80bde158fcb2b048fd0d7/00-manifest.md
+++ b/.tasks/code-review/effect-native/v4-refresh/2a81df063a46bec15bf80bde158fcb2b048fd0d7/00-manifest.md
@@ -2,7 +2,7 @@
 
 - **Date:** 2026-07-10
 - **Repository:** `git@github.com:effect-native/effect-native.git`
-- **PR:** evergreen `v4-refresh` (new PR pending)
+- **PR:** [#282](https://github.com/effect-native/effect-native/pull/282)
 - **Worktree:** `/Users/tom/.codex/worktrees/8458/effect-native`
 - **Target Commit:** `2a81df063a46bec15bf80bde158fcb2b048fd0d7`
 - **Base Commit:** `73087ca4ebe6cb6ddfe52d44f3fafa3ab7ddf8db`

--- a/.tasks/code-review/effect-native/v4-refresh/2a81df063a46bec15bf80bde158fcb2b048fd0d7/00-manifest.md
+++ b/.tasks/code-review/effect-native/v4-refresh/2a81df063a46bec15bf80bde158fcb2b048fd0d7/00-manifest.md
@@ -1,0 +1,9 @@
+# Review Manifest
+
+- **Date:** 2026-07-10
+- **Repository:** `git@github.com:effect-native/effect-native.git`
+- **PR:** evergreen `v4-refresh` (new PR pending)
+- **Worktree:** `/Users/tom/.codex/worktrees/8458/effect-native`
+- **Target Commit:** `2a81df063a46bec15bf80bde158fcb2b048fd0d7`
+- **Base Commit:** `73087ca4ebe6cb6ddfe52d44f3fafa3ab7ddf8db`
+- **Diff Command:** `git diff 73087ca4ebe6cb6ddfe52d44f3fafa3ab7ddf8db..2a81df063a46bec15bf80bde158fcb2b048fd0d7`

--- a/.tasks/code-review/effect-native/v4-refresh/2a81df063a46bec15bf80bde158fcb2b048fd0d7/01-private-notes.md
+++ b/.tasks/code-review/effect-native/v4-refresh/2a81df063a46bec15bf80bde158fcb2b048fd0d7/01-private-notes.md
@@ -1,0 +1,26 @@
+## Code Review Log – evergreen v4-refresh
+
+### 1. Incentive (Hypothesis)
+
+- Claim: The change closes a measured dependency freshness gap.
+- Evidence: npm beta tags are beta.97 while the base lockfile used beta.94.
+
+### 2. Adversarial Attack (Falsification)
+
+- Family skew: searched all four required lock entries; each is beta.97.
+- Unrelated churn: inspected the complete lock diff; changes are limited to the
+  selected family and its dependency metadata, including `multipasta`.
+- API breakage: frozen install, typechecks, type tests, tests, builds, export
+  verification, and docgen all passed through `bun run ok`.
+- Hidden failure: no new source or test code exists in the diff; the forbidden
+  ServiceMap search and `git diff --check` pass.
+
+### 3. Simplicity (Stability)
+
+- Claim: Lockfile-only runtime dependency movement is the smallest viable code delta.
+- Evidence: beta ranges already exist in package manifests; no source edits were needed.
+
+### 4. Reversibility (Safety)
+
+- Claim: The refresh can be reverted without migration or persisted-state changes.
+- Evidence: the runtime delta is dependency resolution only.

--- a/.tasks/code-review/effect-native/v4-refresh/2a81df063a46bec15bf80bde158fcb2b048fd0d7/02-defense-brief.md
+++ b/.tasks/code-review/effect-native/v4-refresh/2a81df063a46bec15bf80bde158fcb2b048fd0d7/02-defense-brief.md
@@ -1,0 +1,19 @@
+# Defense Brief
+
+## Issue: Transitive lockfile movement
+
+- **My Claim:** Transitive metadata could conceal unrelated dependency upgrades.
+- **Defense Hypothesis:** These changes are required by beta.97 package manifests.
+- **Evidence Search:** Compared the complete `bun.lock` diff and beta.97 metadata;
+  platform-node-shared, undici/ws, and Effect-owned dependencies move with the
+  selected family, while the only separate lock entry changed is Effect's
+  `multipasta` resolution.
+- **Verdict:** `withdrawn` — no unrelated root dependency or package manifest changed.
+
+## Issue: Beta API incompatibility
+
+- **My Claim:** The beta.97 family may break unstable platform or SQL APIs.
+- **Defense Hypothesis:** Existing compilation and integration coverage exercises them.
+- **Evidence Search:** `bun run ok` passed typechecks, type tests, tests, builds,
+  subpath verification, and docgen.
+- **Verdict:** `withdrawn` — no observed incompatibility survives the full gate.

--- a/.tasks/code-review/effect-native/v4-refresh/2a81df063a46bec15bf80bde158fcb2b048fd0d7/03-public-response.md
+++ b/.tasks/code-review/effect-native/v4-refresh/2a81df063a46bec15bf80bde158fcb2b048fd0d7/03-public-response.md
@@ -1,0 +1,20 @@
+# Public Response
+
+## Summary
+
+Refreshes the required Effect family from beta.94 to beta.97 and records the
+weekly reconciliation evidence.
+
+## Good
+
+- The lockfile remains on one coherent beta family.
+- No source workaround, skip, fallback, assertion, or behavioral change was added.
+- Every required gate and the broader `ok` suite passed.
+
+## Blockers
+
+None.
+
+## Verdict
+
+`APPROVE`

--- a/.tasks/code-review/effect-native/v4-refresh/2a81df063a46bec15bf80bde158fcb2b048fd0d7/04-thing-golf.md
+++ b/.tasks/code-review/effect-native/v4-refresh/2a81df063a46bec15bf80bde158fcb2b048fd0d7/04-thing-golf.md
@@ -1,0 +1,16 @@
+# Thing Golf
+
+## Scored thing
+
+`MODIFY`: resolve the existing Effect beta dependency family at beta.97.
+
+| Axis | Score | Evidence |
+| --- | ---: | --- |
+| Safety / Explosiveness | 1 | Runtime dependencies move, but the full CI-equivalent gate passes. |
+| Lightness / Burden | 0 | No new dependency or public surface is added. |
+| Clarity / Chaos | -1 | One coherent family replaces the stale family. |
+| Trustworthy / Betraying | -1 | Reconciliation and executable gate evidence make status explicit. |
+| Freedom / Control-Freak | 0 | No new configuration or coupling is introduced. |
+
+**ThingBadness: -1.** The refresh reduces stale-version and misleading-health
+liability without adding a maintained surface.

--- a/.tasks/code-review/effect-native/v4-refresh/5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035/00-manifest.md
+++ b/.tasks/code-review/effect-native/v4-refresh/5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035/00-manifest.md
@@ -1,0 +1,9 @@
+# Review Manifest
+
+- **Date:** 2026-07-17
+- **Repository:** `git@github.com:effect-native/effect-native.git`
+- **PR:** #282
+- **Worktree:** `/Users/tom/.codex/worktrees/8458/effect-native`
+- **Target Commit:** `5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035`
+- **Base Commit:** `73087ca4ebe6cb6ddfe52d44f3fafa3ab7ddf8db`
+- **Diff Command:** `git diff 73087ca4ebe6cb6ddfe52d44f3fafa3ab7ddf8db..5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035`

--- a/.tasks/code-review/effect-native/v4-refresh/5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035/01-private-notes.md
+++ b/.tasks/code-review/effect-native/v4-refresh/5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035/01-private-notes.md
@@ -1,0 +1,35 @@
+## Code Review Log – https://github.com/effect-native/effect-native/pull/282
+
+### 1. Incentive (Hypothesis)
+
+- Claim: The refresh closes real dependency drift without broadening the API.
+- Evidence: `.ok/effect-refresh.ok.md` requires the four registry beta tags to
+  match `bun.lock`; npm reports beta.99 while the prior lock held beta.97.
+
+### 2. Adversarial Attack (Falsification)
+
+- Claim: I tried to break this refresh.
+- Attack scenarios:
+  - Family split: verified all four required lock entries and the transitive
+    platform-node-shared peer family resolve to beta.99.
+  - Resolver pollution: an initial root update added root dependencies and
+    selected stable platform packages; those edits were removed and the frozen
+    install verifies the corrected lock.
+  - API drift: `bun run ok` exercised classic and native typecheckers, type
+    tests, package tests, builds, export verification, and docgen.
+  - Hidden failure behavior: the target commit adds no source, test skip,
+    fallback, assertion, or native binary change.
+
+### 3. Simplicity (Stability)
+
+- Claim: This is the simplest design possible.
+- Evidence: the runtime delta is five existing lock resolutions: the four
+  requested packages plus their platform-node-shared dependency.
+
+### 4. Reversibility (Safety)
+
+- Claim: We can undo this without fire.
+- Evidence: the beta.99 lock commit is isolated as
+  `5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035`; reverting it restores beta.97.
+
+No blocker or risky finding survived prosecution.

--- a/.tasks/code-review/effect-native/v4-refresh/5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035/02-defense-brief.md
+++ b/.tasks/code-review/effect-native/v4-refresh/5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035/02-defense-brief.md
@@ -1,0 +1,20 @@
+# Defense Brief
+
+## Issue: Beta dependency churn
+
+- **My Claim:** A beta-family update can silently break unstable SQL or platform APIs.
+- **Defense Hypothesis:** The repository's executable gates cover the consumers
+  and would expose incompatible types, docs, tests, builds, or exports.
+- **Evidence Search:** Ran frozen install, lint-fix, docgen, and the complete
+  `bun run ok` gate at the target commit; all exited `0`.
+- **Verdict:** `withdrawn` — no incompatible API or tooling behavior was observed.
+
+## Issue: Lockfile resolver pollution
+
+- **My Claim:** The update may add unrelated dependencies or mix Effect v3 and v4.
+- **Defense Hypothesis:** The final diff and frozen install prove a narrow,
+  internally coherent resolution.
+- **Evidence Search:** `git diff HEAD^..HEAD -- bun.lock package.json` contains
+  no package manifest change and only beta.97-to-beta.99 lock replacements.
+- **Verdict:** `withdrawn` — the final committed delta excludes the falsified
+  resolver attempt.

--- a/.tasks/code-review/effect-native/v4-refresh/5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035/03-public-response.md
+++ b/.tasks/code-review/effect-native/v4-refresh/5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035/03-public-response.md
@@ -1,0 +1,26 @@
+# Public Response
+
+## Summary
+
+This refresh advances the existing Effect v4 beta family from beta.97 to
+beta.99 and updates current DotOK/PREP evidence.
+
+## Good
+
+- All requested packages resolve to one beta.99 family.
+- The final dependency delta is confined to existing lock entries.
+- Frozen install, lint, both typecheck lines, type tests, package tests, builds,
+  export verification, and docgen pass through `bun run ok`.
+- No source workaround, hidden failure, unsafe assertion, or test skip was added.
+- The result follows `.patterns/effect-library-development.md`,
+  `.patterns/jsdoc-documentation.md`, `.patterns/testing-patterns.md`, and
+  `.patterns/platform-integration.md` by keeping failures loud and relying on
+  executable type, documentation, integration, and build evidence.
+
+## Blockers
+
+None.
+
+## Verdict
+
+`APPROVE`

--- a/.tasks/code-review/effect-native/v4-refresh/5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035/04-thing-golf.md
+++ b/.tasks/code-review/effect-native/v4-refresh/5b265b6be9adf6d4dd5ef05bdbf10f6d8699c035/04-thing-golf.md
@@ -1,0 +1,16 @@
+# Thing Golf
+
+## Thing: Effect beta-family lock resolution
+
+`MODIFY`: resolve the existing Effect beta dependency family at beta.99.
+
+| Axis                    | Score | Evidence                                                           |
+| ----------------------- | ----: | ------------------------------------------------------------------ |
+| Safety / Explosiveness  |     1 | Runtime dependencies move, but the full CI-equivalent gate passes. |
+| Lightness / Burden      |     0 | No dependency declaration or public surface is added.              |
+| Clarity / Chaos         |    -1 | One coherent family replaces the stale beta.97 resolution.         |
+| Trustworthy / Betraying |    -1 | DotOK and executable gate evidence make health explicit.           |
+| Freedom / Control-Freak |     0 | No new configuration, approval, or coupling is introduced.         |
+
+**ThingBadness: -1.** The refresh reduces stale-version and misleading-health
+liability without adding a maintained surface.

--- a/.tasks/work-orders.md
+++ b/.tasks/work-orders.md
@@ -1,4 +1,4 @@
 # Current Work Orders
 
-1. Publish the reviewed evergreen refresh branch and ready PR.
-   - done_when: `gh pr list --repo effect-native/effect-native --head v4-refresh --base v4 --state open --json url`
+No active work orders. The beta.97 refresh is validated, pushed, and represented
+by ready PR #282 into `v4`.

--- a/.tasks/work-orders.md
+++ b/.tasks/work-orders.md
@@ -1,0 +1,4 @@
+# Current Work Orders
+
+1. Publish the reviewed evergreen refresh branch and ready PR.
+   - done_when: `gh pr list --repo effect-native/effect-native --head v4-refresh --base v4 --state open --json url`

--- a/.tasks/work-orders.md
+++ b/.tasks/work-orders.md
@@ -1,4 +1,7 @@
 # Current Work Orders
 
-No active work orders. The beta.97 refresh is validated, pushed, and represented
-by ready PR #282 into `v4`.
+1. Record the adversarial code-review and Thing Golf artifacts for the committed
+   beta.99 refresh.
+   - done_when: `test -f .tasks/code-review/effect-native/v4-refresh/$(git rev-parse HEAD)/03-public-response.md`
+2. Push `v4-refresh` and refresh ready PR #282 into `v4`.
+   - done_when: `gh pr list --repo effect-native/effect-native --head v4-refresh --base v4 --state open --json number,url`

--- a/.tasks/work-orders.md
+++ b/.tasks/work-orders.md
@@ -1,7 +1,4 @@
 # Current Work Orders
 
-1. Record the adversarial code-review and Thing Golf artifacts for the committed
-   beta.99 refresh.
-   - done_when: `test -f .tasks/code-review/effect-native/v4-refresh/$(git rev-parse HEAD)/03-public-response.md`
-2. Push `v4-refresh` and refresh ready PR #282 into `v4`.
-   - done_when: `gh pr list --repo effect-native/effect-native --head v4-refresh --base v4 --state open --json number,url`
+No active work orders. The beta.99 refresh is validated, reviewed, pushed, and
+represented by ready PR #282 into `v4`.

--- a/PREP/01-WORKING-MODEL.md
+++ b/PREP/01-WORKING-MODEL.md
@@ -1,11 +1,13 @@
 # Working Model
 
 The weekly refresh should be a narrow dependency-family update from Effect
-`4.0.0-beta.94` to `4.0.0-beta.97`. The primary hypothesis is that updating
+`4.0.0-beta.97` to `4.0.0-beta.99`. The primary hypothesis is that updating
 `bun.lock` will reveal any real API or tooling incompatibilities through the
 existing lint, docgen, and `ok` gates; those failures, rather than assumptions,
 will determine whether source edits are required.
 
-The initial assumption that the configured worktree existed was falsified. It
-was reconstructed from `effect-native/effect-native`, then `v4-refresh` was
-created from and rebased on `origin/v4` at `73087ca4`.
+That model survived: the four required packages resolve at beta.99 and all
+CI-equivalent gates pass without source edits. The assumption that a root-level
+targeted `bun update` would preserve workspace ownership was falsified; the
+working resolver path is a workspace-filtered beta update followed by removal
+of Bun's incidental root dependency entries.

--- a/PREP/01-WORKING-MODEL.md
+++ b/PREP/01-WORKING-MODEL.md
@@ -1,0 +1,11 @@
+# Working Model
+
+The weekly refresh should be a narrow dependency-family update from Effect
+`4.0.0-beta.94` to `4.0.0-beta.97`. The primary hypothesis is that updating
+`bun.lock` will reveal any real API or tooling incompatibilities through the
+existing lint, docgen, and `ok` gates; those failures, rather than assumptions,
+will determine whether source edits are required.
+
+The initial assumption that the configured worktree existed was falsified. It
+was reconstructed from `effect-native/effect-native`, then `v4-refresh` was
+created from and rebased on `origin/v4` at `73087ca4`.

--- a/PREP/02-EVIDENCE-LOG.md
+++ b/PREP/02-EVIDENCE-LOG.md
@@ -1,0 +1,8 @@
+# Evidence Log
+
+- [FALSIFIES] `/Users/tom/.codex/worktrees/8458/effect-native` was absent at run start.
+- [SUPPORTS] GitHub identifies `effect-native/effect-native` as the repository.
+- [SUPPORTS] `v4-refresh` is based on current `origin/v4` at `73087ca4`.
+- [SUPPORTS] `bun.lock` resolves the required Effect family at `4.0.0-beta.94`.
+- [SUPPORTS] npm reports `4.0.0-beta.97` as the beta tag for all four required packages.
+- [SUPPORTS] effect-smol fast-forwarded to `5946da38`; untracked `CLAUDE.md` remains.

--- a/PREP/02-EVIDENCE-LOG.md
+++ b/PREP/02-EVIDENCE-LOG.md
@@ -1,8 +1,9 @@
 # Evidence Log
 
-- [FALSIFIES] `/Users/tom/.codex/worktrees/8458/effect-native` was absent at run start.
-- [SUPPORTS] GitHub identifies `effect-native/effect-native` as the repository.
+- [SUPPORTS] `/Users/tom/.codex/worktrees/8458/effect-native` exists and began clean on `v4-refresh`.
 - [SUPPORTS] `v4-refresh` is based on current `origin/v4` at `73087ca4`.
-- [SUPPORTS] `bun.lock` resolves the required Effect family at `4.0.0-beta.94`.
-- [SUPPORTS] npm reports `4.0.0-beta.97` as the beta tag for all four required packages.
-- [SUPPORTS] effect-smol fast-forwarded to `5946da38`; untracked `CLAUDE.md` remains.
+- [SUPPORTS] npm reports `4.0.0-beta.99` as the beta tag for all four required packages.
+- [SUPPORTS] effect-smol fast-forwarded to `3a1128c7`; untracked `CLAUDE.md` remains.
+- [FALSIFIES] An unfiltered root update selected stable v3-family platform packages and added root dependencies.
+- [SUPPORTS] The corrected lock resolves `effect`, `@effect/platform-node`, `@effect/sql-sqlite-bun`, and `@effect/sql-sqlite-node` at `4.0.0-beta.99`.
+- [SUPPORTS] Frozen install, lint-fix, docgen, and the full `bun run ok` gate exit `0`.

--- a/PREP/03-CONSTANTS.md
+++ b/PREP/03-CONSTANTS.md
@@ -1,0 +1,7 @@
+# Constants
+
+- Failures remain loud and structured; no skips, no-op fallbacks, or guards hide them.
+- No unsafe assertions or `try`/`catch` inside `Effect.gen`.
+- The Effect packages must resolve to one current beta family.
+- `bun install --frozen-lockfile`, lint-fix, docgen, and `ok` must pass.
+- The branch is pushed and represented by a ready PR into `v4`, but never merged here.

--- a/PREP/04-STRESS-TEST.md
+++ b/PREP/04-STRESS-TEST.md
@@ -5,3 +5,5 @@
 - Native SQLite addons may expose an ABI mismatch during the full `ok` gate.
 - Doc examples may compile against APIs not exercised by normal package builds.
 - A pre-existing PR may point at a rebased history and require force-with-lease.
+- Bun may treat explicitly named packages as new root dependencies instead of
+  updating the existing workspace-owned `beta` specifications.

--- a/PREP/04-STRESS-TEST.md
+++ b/PREP/04-STRESS-TEST.md
@@ -1,0 +1,7 @@
+# Stress Test
+
+- The beta update may change unstable SQL or platform APIs and require source migration.
+- Lockfile regeneration may pull unrelated transitive updates that break tooling.
+- Native SQLite addons may expose an ABI mismatch during the full `ok` gate.
+- Doc examples may compile against APIs not exercised by normal package builds.
+- A pre-existing PR may point at a rebased history and require force-with-lease.

--- a/PREP/05-THEORETICAL-FRAMEWORK.md
+++ b/PREP/05-THEORETICAL-FRAMEWORK.md
@@ -1,0 +1,6 @@
+# Theoretical Framework
+
+Change only the dependency resolution needed to select the current beta family,
+then use the repository gates as the executable specification. Resolve observed
+API drift using `.patterns/` and the current effect-smol source. Keep each repair
+typed, explicit, and within the existing package boundary.

--- a/PREP/06-IMPACT-ASSESSMENT.md
+++ b/PREP/06-IMPACT-ASSESSMENT.md
@@ -4,3 +4,5 @@ The refresh intentionally accepts beta API churn while minimizing unrelated
 surface-area changes. The chief practical risks are a broad monorepo regression
 or misleading green status. Running the frozen install and all repository gates,
 followed by adversarial review of the committed diff, addresses both risks.
+The observed beta.99 update changes only lock resolution, so it adds no public
+surface or new maintained dependency declaration.

--- a/PREP/06-IMPACT-ASSESSMENT.md
+++ b/PREP/06-IMPACT-ASSESSMENT.md
@@ -1,0 +1,6 @@
+# Impact Assessment
+
+The refresh intentionally accepts beta API churn while minimizing unrelated
+surface-area changes. The chief practical risks are a broad monorepo regression
+or misleading green status. Running the frozen install and all repository gates,
+followed by adversarial review of the committed diff, addresses both risks.

--- a/bun.lock
+++ b/bun.lock
@@ -506,13 +506,13 @@
 
     "@effect/markdown-toc": ["@effect/markdown-toc@0.1.0", "", { "dependencies": { "concat-stream": "^1.5.2", "diacritics-map": "^0.1.0", "gray-matter": "^3.1.1", "lazy-cache": "^2.0.2", "list-item": "^1.1.1", "markdown-link": "^0.1.1", "minimist": "^1.2.0", "mixin-deep": "^1.1.3", "object.pick": "^1.2.0", "remarkable": "^1.7.1", "repeat-string": "^1.6.1", "strip-color": "^0.1.0" }, "bin": { "markdown-toc": "cli.js" } }, "sha512-IRfvvwqQLabVTIw9hhIj4scOGIYPfa13QuEFv+dBWE6p47R+RR0J8jQvfDINFf0Vn80XXVjNRtZxkZpkKXLx2A=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.94", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.94", "mime": "^4.1.0", "undici": "^8.2.0" }, "peerDependencies": { "effect": "^4.0.0-beta.94", "ioredis": "^5.7.0" } }, "sha512-3WhV5ZN2pTPcOtEQlM66Ve0/B4EzF88sYBml97NnRV7BA5Kx0FYLSslc/4aWoaXj6XwuWOxmoXeGGeFzw4gbMQ=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.97", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.97", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.97", "ioredis": "^5.7.0" } }, "sha512-Vd40VLh+Y08Bs37KWtbe9AgO2+t3RKZKGX9YC6ZKAcswu4tXR3CwSI7V2MN+GgS+ez/GLmqH1WrzDDlaIAxKPA=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.94", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.94" } }, "sha512-8mCen8dhL4ockkkxevKdFOXqR8sksuZcPwyqkKZv3w30TIdj4TKXG5sQODmpPFI0+/quwm5T78kodqf/QlZwoA=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.97", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.97" } }, "sha512-sAlygOlDLLERk7fC24f7Aa4G3wkEbGyyMEileHTHU2fThiPYSGMqNRK1LLnNr17m2+JR7BHbycwXkJkM18BAQw=="],
 
-    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-beta.94", "", { "peerDependencies": { "effect": "^4.0.0-beta.94" } }, "sha512-y9ljOuwpz8e6yAZJ6zENUVlF36pSnO8yBYcrFGSG3BEfnofAjD+08nzvbSB+ji3+l3YXmODM9wjUN10H/z4+mw=="],
+    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-beta.97", "", { "peerDependencies": { "effect": "^4.0.0-beta.97" } }, "sha512-bLEcfiYoW1tQTmBU21/DBbNBlZ7kz5gTAr99OlGL9ObvdmCU64KnzR+vyPFsOACW6/+Yx5goNZICFoUoNjEGug=="],
 
-    "@effect/sql-sqlite-node": ["@effect/sql-sqlite-node@4.0.0-beta.94", "", { "peerDependencies": { "effect": "^4.0.0-beta.94" } }, "sha512-lHozTc9QR5Q/xJb1xmGIBs0fG0hPIFMSHzLNtihx/0l6kGElCfjXnNVscmDkCJpfHqrm4SXcfaHqXQm0OZihKQ=="],
+    "@effect/sql-sqlite-node": ["@effect/sql-sqlite-node@4.0.0-beta.97", "", { "peerDependencies": { "effect": "^4.0.0-beta.97" } }, "sha512-mzP67KmXK2vGU3GrlOdM0TWST7mWI8kMNqPu7Gl2I30eSv+DmBes1qYVIQWUnE3b5ka2LCP7iFzjxNjtIfqn8g=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -882,7 +882,7 @@
 
     "dprint": ["dprint@0.51.1", "", { "optionalDependencies": { "@dprint/darwin-arm64": "0.51.1", "@dprint/darwin-x64": "0.51.1", "@dprint/linux-arm64-glibc": "0.51.1", "@dprint/linux-arm64-musl": "0.51.1", "@dprint/linux-loong64-glibc": "0.51.1", "@dprint/linux-loong64-musl": "0.51.1", "@dprint/linux-riscv64-glibc": "0.51.1", "@dprint/linux-x64-glibc": "0.51.1", "@dprint/linux-x64-musl": "0.51.1", "@dprint/win32-arm64": "0.51.1", "@dprint/win32-x64": "0.51.1" }, "bin": { "dprint": "bin.js" } }, "sha512-CEx+wYARxLAe9o7RCZ77GKae6DF7qjn5Rd98xbWdA3hB4PFBr+kHwLANmNHscNumBAIrCg5ZJj/Kz+OYbJ+GBA=="],
 
-    "effect": ["effect@4.0.0-beta.94", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-Q8BrCNbp/3Uh+7xQYHphZBkNfm2SJnl1frQ+8yWfd/j3SU3cL13D38cBMLcnULupwza2Nt4DrjZoMzHWL3CoxQ=="],
+    "effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
 
     "effect-native": ["effect-native@workspace:packages/effect-native"],
 
@@ -1098,7 +1098,7 @@
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
 
-    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+    "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -506,13 +506,13 @@
 
     "@effect/markdown-toc": ["@effect/markdown-toc@0.1.0", "", { "dependencies": { "concat-stream": "^1.5.2", "diacritics-map": "^0.1.0", "gray-matter": "^3.1.1", "lazy-cache": "^2.0.2", "list-item": "^1.1.1", "markdown-link": "^0.1.1", "minimist": "^1.2.0", "mixin-deep": "^1.1.3", "object.pick": "^1.2.0", "remarkable": "^1.7.1", "repeat-string": "^1.6.1", "strip-color": "^0.1.0" }, "bin": { "markdown-toc": "cli.js" } }, "sha512-IRfvvwqQLabVTIw9hhIj4scOGIYPfa13QuEFv+dBWE6p47R+RR0J8jQvfDINFf0Vn80XXVjNRtZxkZpkKXLx2A=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.97", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.97", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.97", "ioredis": "^5.7.0" } }, "sha512-Vd40VLh+Y08Bs37KWtbe9AgO2+t3RKZKGX9YC6ZKAcswu4tXR3CwSI7V2MN+GgS+ez/GLmqH1WrzDDlaIAxKPA=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.99", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.99", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.99", "ioredis": "^5.7.0" } }, "sha512-jnK2KMW4W50AEOKK+Tgvab3YPHBxa3ApLQE8BCad+LH57JOziKzOjqtEpAgJgmao3t77x1UESK4JraaHJDHaYA=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.97", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.97" } }, "sha512-sAlygOlDLLERk7fC24f7Aa4G3wkEbGyyMEileHTHU2fThiPYSGMqNRK1LLnNr17m2+JR7BHbycwXkJkM18BAQw=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.99", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.99" } }, "sha512-POBAowafsAAb3bH1x1rJlWnv32yMAazFgEuRW5LhkW/JJA5VGoEk9OnuoUkIH1OW6K/X6IrdNpqcO+5e9lPQJA=="],
 
-    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-beta.97", "", { "peerDependencies": { "effect": "^4.0.0-beta.97" } }, "sha512-bLEcfiYoW1tQTmBU21/DBbNBlZ7kz5gTAr99OlGL9ObvdmCU64KnzR+vyPFsOACW6/+Yx5goNZICFoUoNjEGug=="],
+    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-beta.99", "", { "peerDependencies": { "effect": "^4.0.0-beta.99" } }, "sha512-3htc9hPNghxCGdUgx4f/yzoUchTYnnueBb03n+62gqXXdi7GI1bEhtGPkFhXHkmoyAdcmddEO79aoGPmdyyyAA=="],
 
-    "@effect/sql-sqlite-node": ["@effect/sql-sqlite-node@4.0.0-beta.97", "", { "peerDependencies": { "effect": "^4.0.0-beta.97" } }, "sha512-mzP67KmXK2vGU3GrlOdM0TWST7mWI8kMNqPu7Gl2I30eSv+DmBes1qYVIQWUnE3b5ka2LCP7iFzjxNjtIfqn8g=="],
+    "@effect/sql-sqlite-node": ["@effect/sql-sqlite-node@4.0.0-beta.99", "", { "peerDependencies": { "effect": "^4.0.0-beta.99" } }, "sha512-43fKlLxWADCDdRYU+ZTig/xeYfyXQOR+j+A0Tp1dZRpztfH8xIkz7o8XxAgcAZMlW3a0EmaHdlgFSU7itziRog=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -882,7 +882,7 @@
 
     "dprint": ["dprint@0.51.1", "", { "optionalDependencies": { "@dprint/darwin-arm64": "0.51.1", "@dprint/darwin-x64": "0.51.1", "@dprint/linux-arm64-glibc": "0.51.1", "@dprint/linux-arm64-musl": "0.51.1", "@dprint/linux-loong64-glibc": "0.51.1", "@dprint/linux-loong64-musl": "0.51.1", "@dprint/linux-riscv64-glibc": "0.51.1", "@dprint/linux-x64-glibc": "0.51.1", "@dprint/linux-x64-musl": "0.51.1", "@dprint/win32-arm64": "0.51.1", "@dprint/win32-x64": "0.51.1" }, "bin": { "dprint": "bin.js" } }, "sha512-CEx+wYARxLAe9o7RCZ77GKae6DF7qjn5Rd98xbWdA3hB4PFBr+kHwLANmNHscNumBAIrCg5ZJj/Kz+OYbJ+GBA=="],
 
-    "effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
+    "effect": ["effect@4.0.0-beta.99", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-hP1C61uzINfLl/4kKMwcqksxd34s4sQ3VSjsWjhGrkx9CRlXaqnfOK9dpTEKynQ6rA7wU9rb3c+48eDYw7uzxA=="],
 
     "effect-native": ["effect-native@workspace:packages/effect-native"],
 


### PR DESCRIPTION
## Summary

- refresh `effect`, `@effect/platform-node`, `@effect/sql-sqlite-bun`, and `@effect/sql-sqlite-node` from `4.0.0-beta.97` to `4.0.0-beta.99`
- keep the Effect dependency family coherent and record current DotOK/PREP evidence
- add adversarial code-review and Thing Golf artifacts for the beta.99 refresh commit

## Validation

- `bun install --frozen-lockfile`
- `bun run lint-fix`
- `bun run docgen`
- `bun run ok`
- removed ServiceMap guidance search
- `git diff --check origin/v4..HEAD`

## Review status

- final adversarial review verdict: `APPROVE`
- Thing Golf score: `-1`
- no source workarounds, test skips, fallbacks, assertions, root dependency declarations, or native binary changes

## Reference

- effect-smol fast-forwarded to `3a1128c7684e04d34d9f541f77adaac38a513056`; local untracked `CLAUDE.md` preserved

This ready PR targets `v4` from the evergreen `v4-refresh` branch. Do not merge as part of the automation.
